### PR TITLE
Observe implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,13 +58,13 @@ extern crate alloc;
 pub mod error;
 
 mod header;
+mod observe;
 mod packet;
 mod request;
 mod response;
 
-pub use header::{
-    Header, HeaderRaw, MessageClass, MessageType, RequestType, ResponseType,
-};
-pub use packet::{CoapOption, ContentFormat, Packet};
+pub use header::{Header, HeaderRaw, MessageClass, MessageType, RequestType, ResponseType};
+pub use observe::Subject;
+pub use packet::{CoapOption, ContentFormat, ObserveOption, Packet};
 pub use request::CoapRequest;
 pub use response::CoapResponse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,9 @@ mod packet;
 mod request;
 mod response;
 
-pub use header::{Header, HeaderRaw, MessageClass, MessageType, RequestType, ResponseType};
+pub use header::{
+    Header, HeaderRaw, MessageClass, MessageType, RequestType, ResponseType,
+};
 pub use observe::Subject;
 pub use packet::{CoapOption, ContentFormat, ObserveOption, Packet};
 pub use request::CoapRequest;

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -1,0 +1,290 @@
+use super::request::CoapRequest;
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt::Display;
+use core::marker::PhantomData;
+
+const DEFAULT_UNACKNOWLEDGED_LIMIT: u8 = 10;
+
+type ResourcePath = String;
+
+pub struct Observer<Endpoint: Display> {
+    pub endpoint: Endpoint,
+    pub token: Vec<u8>,
+    unacknowledged_messages: u8,
+}
+
+pub struct Resource<Endpoint: Display> {
+    pub observers: Vec<Observer<Endpoint>>,
+    pub sequence: u32,
+}
+
+pub struct Subject<Endpoint: Display + PartialEq> {
+    resources: BTreeMap<ResourcePath, Resource<Endpoint>>,
+    unacknowledged_limit: u8,
+    phantom: PhantomData<Endpoint>,
+}
+
+impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
+    pub fn register(&mut self, request: &CoapRequest<Endpoint>) {
+        let observer_endpoint = request.source.as_ref().unwrap();
+        let resource_path = request.get_path();
+        let token = request.message.get_token();
+
+        #[cfg(test)]
+        println!("register {} {}", observer_endpoint, resource_path);
+
+        let observer = Observer {
+            endpoint: observer_endpoint.clone(),
+            token: token.clone(),
+            unacknowledged_messages: 0,
+        };
+
+        let resource = self.resources.entry(resource_path).or_insert(Resource {
+            observers: Vec::new(),
+            sequence: 0,
+        });
+
+        if let Some(position) = resource
+            .observers
+            .iter()
+            .position(|x| x.endpoint == observer.endpoint)
+        {
+            resource.observers[position] = observer;
+        } else {
+            resource.observers.push(observer);
+        }
+    }
+
+    pub fn deregister(&mut self, request: &CoapRequest<Endpoint>) {
+        let observer_endpoint = request.source.as_ref().unwrap();
+        let resource_path = request.get_path();
+        let token = request.message.get_token();
+
+        #[cfg(test)]
+        println!("deregister {} {}", observer_endpoint, resource_path);
+
+        if let Some(resource) = self.resources.get_mut(&resource_path) {
+            let position = resource
+                .observers
+                .iter()
+                .position(|x| x.endpoint == *observer_endpoint && x.token == *token);
+
+            if let Some(position) = position {
+                resource.observers.remove(position);
+            }
+        }
+    }
+
+    pub fn resource_changed(&mut self, resource: &str) {
+        let unacknowledged_limit = self.unacknowledged_limit;
+
+        #[cfg(test)]
+        println!("Resource changed {}", resource);
+
+        self.resources
+            .entry(resource.to_string())
+            .and_modify(|resource| {
+                resource.sequence += 1;
+
+                resource.observers.iter_mut().for_each(|observer| {
+                    observer.unacknowledged_messages += 1;
+                });
+
+                resource
+                    .observers
+                    .retain(|observer| observer.unacknowledged_messages <= unacknowledged_limit);
+            });
+    }
+
+    pub fn acknowledge(&mut self, request: &CoapRequest<Endpoint>) {
+        let observer_endpoint = request.source.as_ref().unwrap();
+        let resource_path = request.get_path();
+        let token = request.message.get_token();
+
+        if let Some(resource) = self.resources.get_mut(&resource_path) {
+            let observer = resource
+                .observers
+                .iter_mut()
+                .find(|x| x.endpoint == *observer_endpoint && x.token == *token);
+
+            if let Some(observer) = observer {
+                observer.unacknowledged_messages = 0;
+            }
+        }
+    }
+
+    pub fn get_resource(&self, resource: &str) -> Option<&Resource<Endpoint>> {
+        self.resources.get(resource)
+    }
+
+    pub fn get_resource_observers(&self, resource: &str) -> Option<Vec<&Observer<Endpoint>>> {
+        self.resources
+            .get(resource)
+            .map(|resource| resource.observers.iter().collect())
+    }
+
+    pub fn set_unacknowledged_limit(&mut self, limit: u8) {
+        self.unacknowledged_limit = limit;
+    }
+}
+
+impl<Endpoint: Display + PartialEq + Clone> Default for Subject<Endpoint> {
+    fn default() -> Self {
+        Subject {
+            resources: BTreeMap::new(),
+            unacknowledged_limit: DEFAULT_UNACKNOWLEDGED_LIMIT,
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::{RequestType as Method, ResponseType as Status, *};
+    use super::*;
+    use alloc::vec;
+
+    type Endpoint = String;
+
+    #[test]
+    fn register() {
+        let resource_path = "temp";
+
+        let mut request = CoapRequest::new();
+        request.source = Some(String::from("0.0.0.0"));
+        request.set_method(Method::Get);
+        request.set_path(resource_path.clone());
+        request.message.set_token(vec![0x7d, 0x34]);
+        request
+            .message
+            .set_observe(vec![ObserveOption::Register as u8]);
+
+        let mut subject: Subject<Endpoint> = Subject::default();
+        subject.register(&request);
+
+        let observers = subject
+            .get_resource_observers(resource_path.clone())
+            .unwrap();
+
+        assert_eq!(observers.len(), 1);
+    }
+
+    #[test]
+    fn register_replace() {
+        let resource_path = "temp";
+
+        let mut request1 = CoapRequest::new();
+        request1.source = Some(String::from("0.0.0.0"));
+        request1.set_method(Method::Get);
+        request1.set_path(resource_path.clone());
+        request1.message.set_token(vec![0x00, 0x00]);
+        request1
+            .message
+            .set_observe(vec![ObserveOption::Register as u8]);
+
+        let mut request2 = CoapRequest::new();
+        request2.source = Some(String::from("0.0.0.0"));
+        request2.set_method(Method::Get);
+        request2.set_path(resource_path.clone());
+        request2.message.set_token(vec![0xff, 0xff]);
+        request2
+            .message
+            .set_observe(vec![ObserveOption::Register as u8]);
+
+        let mut subject: Subject<Endpoint> = Subject::default();
+        subject.register(&request1);
+        subject.register(&request2);
+
+        let observers = subject
+            .get_resource_observers(resource_path.clone())
+            .unwrap();
+
+        assert_eq!(observers.len(), 1);
+
+        let observer = observers.get(0).unwrap();
+
+        assert_eq!(observer.token, vec![0xff, 0xff]);
+    }
+
+    #[test]
+    fn ack_flow_ok() {
+        let resource_path = "temp";
+
+        let mut request1 = CoapRequest::new();
+        request1.source = Some(String::from("0.0.0.0"));
+        request1.set_method(Method::Get);
+        request1.set_path(resource_path.clone());
+        request1.message.set_token(vec![0x00, 0x00]);
+        request1
+            .message
+            .set_observe(vec![ObserveOption::Register as u8]);
+
+        let mut subject: Subject<Endpoint> = Subject::default();
+        subject.register(&request1);
+
+        let sequence1 = subject.get_resource(resource_path).unwrap().sequence;
+        subject.resource_changed(resource_path);
+        let sequence2 = subject.get_resource(resource_path).unwrap().sequence;
+
+        assert!(sequence2 > sequence1);
+
+        {
+            let observers = subject
+                .get_resource_observers(resource_path.clone())
+                .unwrap();
+            let observer = observers.get(0).unwrap();
+
+            assert_eq!(observer.unacknowledged_messages, 1);
+        }
+
+        let mut ack = CoapRequest::new();
+        ack.source = Some(String::from("0.0.0.0"));
+        ack.message.header.set_type(MessageType::Acknowledgement);
+        ack.set_path(resource_path.clone());
+        ack.message.set_token(vec![0x00, 0x00]);
+
+        subject.acknowledge(&ack);
+
+        {
+            let observers = subject
+                .get_resource_observers(resource_path.clone())
+                .unwrap();
+            let observer = observers.get(0).unwrap();
+
+            assert_eq!(observer.unacknowledged_messages, 0);
+        }
+    }
+
+    #[test]
+    fn ack_flow_forget_observer() {
+        let resource_path = "temp";
+
+        let mut request1 = CoapRequest::new();
+        request1.source = Some(String::from("0.0.0.0"));
+        request1.set_method(Method::Get);
+        request1.set_path(resource_path.clone());
+        request1.message.set_token(vec![0x00, 0x00]);
+        request1
+            .message
+            .set_observe(vec![ObserveOption::Register as u8]);
+
+        let mut subject: Subject<Endpoint> = Subject::default();
+        subject.set_unacknowledged_limit(5);
+        subject.register(&request1);
+
+        subject.resource_changed(resource_path);
+        subject.resource_changed(resource_path);
+        subject.resource_changed(resource_path);
+        subject.resource_changed(resource_path);
+        subject.resource_changed(resource_path);
+        subject.resource_changed(resource_path);
+
+        let observers = subject
+            .get_resource_observers(resource_path.clone())
+            .unwrap();
+
+        assert_eq!(observers.len(), 0);
+    }
+}

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -1,9 +1,11 @@
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{fmt::Display, marker::PhantomData};
+
 use super::request::CoapRequest;
-use alloc::collections::BTreeMap;
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
-use core::fmt::Display;
-use core::marker::PhantomData;
 
 const DEFAULT_UNACKNOWLEDGED_LIMIT: u8 = 10;
 
@@ -148,9 +150,13 @@ impl<Endpoint: Display + PartialEq + Clone> Default for Subject<Endpoint> {
 
 #[cfg(test)]
 mod test {
-    use super::super::{RequestType as Method, ResponseType as Status, *};
-    use super::*;
-    use alloc::vec;
+    use super::{
+        super::{
+            header::{MessageType, RequestType as Method},
+            packet::ObserveOption,
+        },
+        *,
+    };
 
     type Endpoint = String;
 

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -9,20 +9,20 @@ const DEFAULT_UNACKNOWLEDGED_LIMIT: u8 = 10;
 
 type ResourcePath = String;
 
-/// An Observer client
+/// An observer client.
 pub struct Observer<Endpoint: Display> {
     pub endpoint: Endpoint,
     pub token: Vec<u8>,
     unacknowledged_messages: u8,
 }
 
-/// An observed Resource
+/// An observed resource.
 pub struct Resource<Endpoint: Display> {
     pub observers: Vec<Observer<Endpoint>>,
     pub sequence: u32,
 }
 
-/// Keeps track of the state of the observed Resources
+/// Keeps track of the state of the observed resources.
 pub struct Subject<Endpoint: Display + PartialEq> {
     resources: BTreeMap<ResourcePath, Resource<Endpoint>>,
     unacknowledged_limit: u8,
@@ -30,7 +30,7 @@ pub struct Subject<Endpoint: Display + PartialEq> {
 }
 
 impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
-    /// Register an observer interested in a resource
+    /// Registers an observer interested in a resource.
     pub fn register(&mut self, request: &CoapRequest<Endpoint>) {
         let observer_endpoint = request.source.as_ref().unwrap();
         let resource_path = request.get_path();
@@ -59,7 +59,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
         }
     }
 
-    // Remove an observer from the interested resource
+    // Removes an observer from the interested resource.
     pub fn deregister(&mut self, request: &CoapRequest<Endpoint>) {
         let observer_endpoint = request.source.as_ref().unwrap();
         let resource_path = request.get_path();
@@ -76,8 +76,10 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
         }
     }
 
-    /// Update the resource information after having notified the observers. It increments the resource
-    /// sequence and counter of unacknowledged updates.
+    /// Updates the resource information after having notified the observers.
+    ///
+    /// It increments the resource sequence and counter of unacknowledged
+    /// updates.
     pub fn resource_changed(&mut self, resource: &str) {
         let unacknowledged_limit = self.unacknowledged_limit;
 
@@ -96,7 +98,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
             });
     }
 
-    /// Reset the counter of unacknowledged updates for a resource observer
+    /// Resets the counter of unacknowledged updates for a resource observer.
     pub fn acknowledge(&mut self, request: &CoapRequest<Endpoint>) {
         let observer_endpoint = request.source.as_ref().unwrap();
         let resource_path = request.get_path();
@@ -113,12 +115,12 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
         }
     }
 
-    /// Get the tracked resources
+    /// Gets the tracked resources.
     pub fn get_resource(&self, resource: &str) -> Option<&Resource<Endpoint>> {
         self.resources.get(resource)
     }
 
-    /// Get the observers of a resource
+    /// Gets the observers of a resource.
     pub fn get_resource_observers(
         &self,
         resource: &str,
@@ -128,7 +130,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
             .map(|resource| resource.observers.iter().collect())
     }
 
-    /// Set the limit of unacknowledged updates before removing an observer
+    /// Sets the limit of unacknowledged updates before removing an observer.
     pub fn set_unacknowledged_limit(&mut self, limit: u8) {
         self.unacknowledged_limit = limit;
     }

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -42,10 +42,11 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
             unacknowledged_messages: 0,
         };
 
-        let resource = self.resources.entry(resource_path).or_insert(Resource {
-            observers: Vec::new(),
-            sequence: 0,
-        });
+        let resource =
+            self.resources.entry(resource_path).or_insert(Resource {
+                observers: Vec::new(),
+                sequence: 0,
+            });
 
         if let Some(position) = resource
             .observers
@@ -65,10 +66,9 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
         let token = request.message.get_token();
 
         if let Some(resource) = self.resources.get_mut(&resource_path) {
-            let position = resource
-                .observers
-                .iter()
-                .position(|x| x.endpoint == *observer_endpoint && x.token == *token);
+            let position = resource.observers.iter().position(|x| {
+                x.endpoint == *observer_endpoint && x.token == *token
+            });
 
             if let Some(position) = position {
                 resource.observers.remove(position);
@@ -90,9 +90,9 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
                     observer.unacknowledged_messages += 1;
                 });
 
-                resource
-                    .observers
-                    .retain(|observer| observer.unacknowledged_messages <= unacknowledged_limit);
+                resource.observers.retain(|observer| {
+                    observer.unacknowledged_messages <= unacknowledged_limit
+                });
             });
     }
 
@@ -103,10 +103,9 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
         let token = request.message.get_token();
 
         if let Some(resource) = self.resources.get_mut(&resource_path) {
-            let observer = resource
-                .observers
-                .iter_mut()
-                .find(|x| x.endpoint == *observer_endpoint && x.token == *token);
+            let observer = resource.observers.iter_mut().find(|x| {
+                x.endpoint == *observer_endpoint && x.token == *token
+            });
 
             if let Some(observer) = observer {
                 observer.unacknowledged_messages = 0;
@@ -120,7 +119,10 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
     }
 
     /// Get the observers of a resource
-    pub fn get_resource_observers(&self, resource: &str) -> Option<Vec<&Observer<Endpoint>>> {
+    pub fn get_resource_observers(
+        &self,
+        resource: &str,
+    ) -> Option<Vec<&Observer<Endpoint>>> {
         self.resources
             .get(resource)
             .map(|resource| resource.observers.iter().collect())

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -555,8 +555,7 @@ impl Packet {
 
 #[cfg(test)]
 mod test {
-    use super::super::header;
-    use super::*;
+    use super::{super::header, *};
 
     #[test]
     fn test_decode_packet_with_options() {

--- a/src/request.rs
+++ b/src/request.rs
@@ -23,10 +23,7 @@ impl<Endpoint> CoapRequest<Endpoint> {
     }
 
     /// Creates a request from a packet.
-    pub fn from_packet(
-        packet: Packet,
-        source: Endpoint,
-    ) -> CoapRequest<Endpoint> {
+    pub fn from_packet(packet: Packet, source: Endpoint) -> CoapRequest<Endpoint> {
         CoapRequest {
             response: CoapResponse::new(&packet),
             message: packet,
@@ -79,5 +76,116 @@ impl<Endpoint> CoapRequest<Endpoint> {
             }
             _ => "".to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::header::MessageType;
+    use super::super::packet::{CoapOption, Packet};
+    use super::*;
+    use alloc::string::String;
+
+    struct Endpoint(String);
+
+    #[test]
+    fn test_request_create() {
+        let mut packet = Packet::new();
+        let mut request1: CoapRequest<Endpoint> = CoapRequest::new();
+
+        packet.set_token(vec![0x17, 0x38]);
+        request1.message.set_token(vec![0x17, 0x38]);
+
+        packet.add_option(CoapOption::UriPath, b"test-interface".to_vec());
+        request1
+            .message
+            .add_option(CoapOption::UriPath, b"test-interface".to_vec());
+
+        packet.header.message_id = 42;
+        request1.message.header.message_id = 42;
+
+        packet.header.set_version(2);
+        request1.message.header.set_version(2);
+
+        packet.header.set_type(MessageType::Confirmable);
+        request1.message.header.set_type(MessageType::Confirmable);
+
+        packet.header.set_code("0.04");
+        request1.message.header.set_code("0.04");
+
+        let endpoint = Endpoint(String::from("127.0.0.1:1234"));
+        let request2 = CoapRequest::from_packet(packet, endpoint);
+
+        assert_eq!(
+            request1.message.to_bytes().unwrap(),
+            request2.message.to_bytes().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_method() {
+        let mut request: CoapRequest<Endpoint> = CoapRequest::new();
+
+        request.message.header.set_code("0.01");
+        assert_eq!(&Method::Get, request.get_method());
+
+        request.message.header.set_code("0.02");
+        assert_eq!(&Method::Post, request.get_method());
+
+        request.message.header.set_code("0.03");
+        assert_eq!(&Method::Put, request.get_method());
+
+        request.message.header.set_code("0.04");
+        assert_eq!(&Method::Delete, request.get_method());
+
+        request.set_method(Method::Get);
+        assert_eq!("0.01", request.message.header.get_code());
+
+        request.set_method(Method::Post);
+        assert_eq!("0.02", request.message.header.get_code());
+
+        request.set_method(Method::Put);
+        assert_eq!("0.03", request.message.header.get_code());
+
+        request.set_method(Method::Delete);
+        assert_eq!("0.04", request.message.header.get_code());
+    }
+
+    #[test]
+    fn test_path() {
+        let mut request: CoapRequest<Endpoint> = CoapRequest::new();
+
+        let path = "test-interface";
+        request
+            .message
+            .add_option(CoapOption::UriPath, path.as_bytes().to_vec());
+        assert_eq!(path, request.get_path());
+
+        let path2 = "test-interface2";
+        request.set_path(path2);
+        assert_eq!(
+            path2.as_bytes().to_vec(),
+            *request
+                .message
+                .get_option(CoapOption::UriPath)
+                .unwrap()
+                .front()
+                .unwrap()
+        );
+
+        request.set_path("/test-interface2");
+        assert_eq!(
+            path2.as_bytes().to_vec(),
+            *request
+                .message
+                .get_option(CoapOption::UriPath)
+                .unwrap()
+                .front()
+                .unwrap()
+        );
+
+        let path3 = "test-interface2/";
+        request.set_path(path3);
+        assert_eq!(path3, request.get_path());
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -79,13 +79,15 @@ impl<Endpoint> CoapRequest<Endpoint> {
         }
     }
 
-    pub fn get_observe(&self) -> Option<ObserveOption> {
+    /// Returns the flag in the Observe option
+    pub fn get_observe_flag(&self) -> Option<ObserveOption> {
         self.message
             .get_observe()
-            .and_then(|option| match option[0] {
-                x if x == ObserveOption::Register as u8 => Some(ObserveOption::Register),
-                x if x == ObserveOption::Deregister as u8 => Some(ObserveOption::Deregister),
-                _ => None,
+            .and_then(|option| match option.get(0) {
+                Some(&x) if x == ObserveOption::Register as u8 => Some(ObserveOption::Register),
+                Some(&x) if x == ObserveOption::Deregister as u8 => Some(ObserveOption::Deregister),
+                Some(_) => None,
+                None => Some(ObserveOption::Register), // Value is Register by default if not present
             })
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,5 +1,6 @@
-use super::header::{MessageClass, RequestType as Method};
-use super::packet::{CoapOption, Packet};
+use super::header::MessageClass;
+use super::header::RequestType as Method;
+use super::packet::{CoapOption, ObserveOption, Packet};
 use super::response::CoapResponse;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
@@ -76,6 +77,16 @@ impl<Endpoint> CoapRequest<Endpoint> {
             }
             _ => "".to_string(),
         }
+    }
+
+    pub fn get_observe(&self) -> Option<ObserveOption> {
+        self.message
+            .get_observe()
+            .and_then(|option| match option[0] {
+                x if x == ObserveOption::Register as u8 => Some(ObserveOption::Register),
+                x if x == ObserveOption::Deregister as u8 => Some(ObserveOption::Deregister),
+                _ => None,
+            })
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -82,7 +82,7 @@ impl<Endpoint> CoapRequest<Endpoint> {
         }
     }
 
-    /// Returns the flag in the Observe option
+    /// Returns the flag in the Observe option.
     pub fn get_observe_flag(&self) -> Option<ObserveOption> {
         self.message
             .get_observe()
@@ -94,7 +94,8 @@ impl<Endpoint> CoapRequest<Endpoint> {
                     Some(ObserveOption::Deregister)
                 }
                 Some(_) => None,
-                None => Some(ObserveOption::Register), // Value is Register by default if not present
+                // Value is Register by default if not present
+                None => Some(ObserveOption::Register),
             })
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,9 +1,13 @@
-use super::header::MessageClass;
-use super::header::RequestType as Method;
-use super::packet::{CoapOption, ObserveOption, Packet};
-use super::response::CoapResponse;
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use super::{
+    header::{MessageClass, RequestType as Method},
+    packet::{CoapOption, ObserveOption, Packet},
+    response::CoapResponse,
+};
 
 /// The CoAP request.
 #[derive(Clone, Debug)]
@@ -102,10 +106,7 @@ impl<Endpoint> CoapRequest<Endpoint> {
 
 #[cfg(test)]
 mod test {
-    use super::super::header::MessageType;
-    use super::super::packet::{CoapOption, Packet};
-    use super::*;
-    use alloc::string::String;
+    use super::{super::header::MessageType, *};
 
     struct Endpoint(String);
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -20,11 +20,7 @@ pub struct CoapRequest<Endpoint> {
 impl<Endpoint> CoapRequest<Endpoint> {
     /// Creates a new request.
     pub fn new() -> CoapRequest<Endpoint> {
-        CoapRequest {
-            response: None,
-            message: Packet::new(),
-            source: None,
-        }
+        Default::default()
     }
 
     /// Creates a request from a packet.
@@ -101,6 +97,16 @@ impl<Endpoint> CoapRequest<Endpoint> {
                 // Value is Register by default if not present
                 None => Some(ObserveOption::Register),
             })
+    }
+}
+
+impl<Endpoint> Default for CoapRequest<Endpoint> {
+    fn default() -> Self {
+        CoapRequest {
+            response: None,
+            message: Packet::new(),
+            source: None,
+        }
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -24,7 +24,10 @@ impl<Endpoint> CoapRequest<Endpoint> {
     }
 
     /// Creates a request from a packet.
-    pub fn from_packet(packet: Packet, source: Endpoint) -> CoapRequest<Endpoint> {
+    pub fn from_packet(
+        packet: Packet,
+        source: Endpoint,
+    ) -> CoapRequest<Endpoint> {
         CoapRequest {
             response: CoapResponse::new(&packet),
             message: packet,
@@ -84,8 +87,12 @@ impl<Endpoint> CoapRequest<Endpoint> {
         self.message
             .get_observe()
             .and_then(|option| match option.get(0) {
-                Some(&x) if x == ObserveOption::Register as u8 => Some(ObserveOption::Register),
-                Some(&x) if x == ObserveOption::Deregister as u8 => Some(ObserveOption::Deregister),
+                Some(&x) if x == ObserveOption::Register as u8 => {
+                    Some(ObserveOption::Register)
+                }
+                Some(&x) if x == ObserveOption::Deregister as u8 => {
+                    Some(ObserveOption::Deregister)
+                }
                 Some(_) => None,
                 None => Some(ObserveOption::Register), // Value is Register by default if not present
             })

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,7 @@
-pub use super::header::ResponseType as Status;
-use super::header::{MessageClass, MessageType};
-use super::packet::{ObserveOption, Packet};
+use super::{
+    header::{MessageClass, MessageType, ResponseType as Status},
+    packet::{ObserveOption, Packet},
+};
 
 /// The CoAP response.
 #[derive(Clone, Debug)]
@@ -98,8 +99,6 @@ impl CoapResponse {
 
 #[cfg(test)]
 mod test {
-    use super::super::header::MessageType;
-    use super::super::packet::Packet;
     use super::*;
 
     #[test]

--- a/src/response.rs
+++ b/src/response.rs
@@ -86,7 +86,7 @@ impl CoapResponse {
         }
     }
 
-    // Set the Observe flag
+    // Sets the Observe flag.
     pub fn set_observe_flag(&mut self, value: ObserveOption) {
         let value = match value {
             ObserveOption::Register => alloc::vec![], // Value is not present if Register

--- a/src/response.rs
+++ b/src/response.rs
@@ -43,45 +43,52 @@ impl CoapResponse {
             MessageClass::Response(Status::Content) => &Status::Content,
 
             MessageClass::Response(Status::BadRequest) => &Status::BadRequest,
-            MessageClass::Response(Status::Unauthorized) => {
-                &Status::Unauthorized
-            }
+            MessageClass::Response(Status::Unauthorized) => &Status::Unauthorized,
             MessageClass::Response(Status::BadOption) => &Status::BadOption,
             MessageClass::Response(Status::Forbidden) => &Status::Forbidden,
             MessageClass::Response(Status::NotFound) => &Status::NotFound,
-            MessageClass::Response(Status::MethodNotAllowed) => {
-                &Status::MethodNotAllowed
-            }
-            MessageClass::Response(Status::NotAcceptable) => {
-                &Status::NotAcceptable
-            }
-            MessageClass::Response(Status::PreconditionFailed) => {
-                &Status::PreconditionFailed
-            }
-            MessageClass::Response(Status::RequestEntityTooLarge) => {
-                &Status::RequestEntityTooLarge
-            }
+            MessageClass::Response(Status::MethodNotAllowed) => &Status::MethodNotAllowed,
+            MessageClass::Response(Status::NotAcceptable) => &Status::NotAcceptable,
+            MessageClass::Response(Status::PreconditionFailed) => &Status::PreconditionFailed,
+            MessageClass::Response(Status::RequestEntityTooLarge) => &Status::RequestEntityTooLarge,
             MessageClass::Response(Status::UnsupportedContentFormat) => {
                 &Status::UnsupportedContentFormat
             }
 
-            MessageClass::Response(Status::InternalServerError) => {
-                &Status::InternalServerError
-            }
-            MessageClass::Response(Status::NotImplemented) => {
-                &Status::NotImplemented
-            }
+            MessageClass::Response(Status::InternalServerError) => &Status::InternalServerError,
+            MessageClass::Response(Status::NotImplemented) => &Status::NotImplemented,
             MessageClass::Response(Status::BadGateway) => &Status::BadGateway,
-            MessageClass::Response(Status::ServiceUnavailable) => {
-                &Status::ServiceUnavailable
-            }
-            MessageClass::Response(Status::GatewayTimeout) => {
-                &Status::GatewayTimeout
-            }
-            MessageClass::Response(Status::ProxyingNotSupported) => {
-                &Status::ProxyingNotSupported
-            }
+            MessageClass::Response(Status::ServiceUnavailable) => &Status::ServiceUnavailable,
+            MessageClass::Response(Status::GatewayTimeout) => &Status::GatewayTimeout,
+            MessageClass::Response(Status::ProxyingNotSupported) => &Status::ProxyingNotSupported,
             _ => &Status::UnKnown,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::header::MessageType;
+    use super::super::packet::Packet;
+    use super::*;
+
+    #[test]
+    fn test_new_response_valid() {
+        for mtyp in vec![MessageType::Confirmable, MessageType::NonConfirmable] {
+            let mut packet = Packet::new();
+            packet.header.set_type(mtyp);
+            let opt_resp = CoapResponse::new(&packet);
+            assert!(opt_resp.is_some());
+
+            let response = opt_resp.unwrap();
+            assert_eq!(packet.payload, response.message.payload);
+        }
+    }
+
+    #[test]
+    fn test_new_response_invalid() {
+        let mut packet = Packet::new();
+        packet.header.set_type(MessageType::Acknowledgement);
+        assert!(CoapResponse::new(&packet).is_none());
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -44,24 +44,44 @@ impl CoapResponse {
             MessageClass::Response(Status::Content) => &Status::Content,
 
             MessageClass::Response(Status::BadRequest) => &Status::BadRequest,
-            MessageClass::Response(Status::Unauthorized) => &Status::Unauthorized,
+            MessageClass::Response(Status::Unauthorized) => {
+                &Status::Unauthorized
+            }
             MessageClass::Response(Status::BadOption) => &Status::BadOption,
             MessageClass::Response(Status::Forbidden) => &Status::Forbidden,
             MessageClass::Response(Status::NotFound) => &Status::NotFound,
-            MessageClass::Response(Status::MethodNotAllowed) => &Status::MethodNotAllowed,
-            MessageClass::Response(Status::NotAcceptable) => &Status::NotAcceptable,
-            MessageClass::Response(Status::PreconditionFailed) => &Status::PreconditionFailed,
-            MessageClass::Response(Status::RequestEntityTooLarge) => &Status::RequestEntityTooLarge,
+            MessageClass::Response(Status::MethodNotAllowed) => {
+                &Status::MethodNotAllowed
+            }
+            MessageClass::Response(Status::NotAcceptable) => {
+                &Status::NotAcceptable
+            }
+            MessageClass::Response(Status::PreconditionFailed) => {
+                &Status::PreconditionFailed
+            }
+            MessageClass::Response(Status::RequestEntityTooLarge) => {
+                &Status::RequestEntityTooLarge
+            }
             MessageClass::Response(Status::UnsupportedContentFormat) => {
                 &Status::UnsupportedContentFormat
             }
 
-            MessageClass::Response(Status::InternalServerError) => &Status::InternalServerError,
-            MessageClass::Response(Status::NotImplemented) => &Status::NotImplemented,
+            MessageClass::Response(Status::InternalServerError) => {
+                &Status::InternalServerError
+            }
+            MessageClass::Response(Status::NotImplemented) => {
+                &Status::NotImplemented
+            }
             MessageClass::Response(Status::BadGateway) => &Status::BadGateway,
-            MessageClass::Response(Status::ServiceUnavailable) => &Status::ServiceUnavailable,
-            MessageClass::Response(Status::GatewayTimeout) => &Status::GatewayTimeout,
-            MessageClass::Response(Status::ProxyingNotSupported) => &Status::ProxyingNotSupported,
+            MessageClass::Response(Status::ServiceUnavailable) => {
+                &Status::ServiceUnavailable
+            }
+            MessageClass::Response(Status::GatewayTimeout) => {
+                &Status::GatewayTimeout
+            }
+            MessageClass::Response(Status::ProxyingNotSupported) => {
+                &Status::ProxyingNotSupported
+            }
             _ => &Status::UnKnown,
         }
     }
@@ -84,7 +104,8 @@ mod test {
 
     #[test]
     fn test_new_response_valid() {
-        for mtyp in vec![MessageType::Confirmable, MessageType::NonConfirmable] {
+        for mtyp in vec![MessageType::Confirmable, MessageType::NonConfirmable]
+        {
             let mut packet = Packet::new();
             packet.header.set_type(mtyp);
             let opt_resp = CoapResponse::new(&packet);

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,6 @@
-use super::header::{MessageClass, MessageType, ResponseType as Status};
-use super::packet::Packet;
+pub use super::header::ResponseType as Status;
+use super::header::{MessageClass, MessageType};
+use super::packet::{ObserveOption, Packet};
 
 /// The CoAP response.
 #[derive(Clone, Debug)]
@@ -63,6 +64,10 @@ impl CoapResponse {
             MessageClass::Response(Status::ProxyingNotSupported) => &Status::ProxyingNotSupported,
             _ => &Status::UnKnown,
         }
+    }
+
+    pub fn set_observe(&mut self, value: ObserveOption) {
+        self.message.set_observe(alloc::vec![value as u8]);
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -66,8 +66,13 @@ impl CoapResponse {
         }
     }
 
-    pub fn set_observe(&mut self, value: ObserveOption) {
-        self.message.set_observe(alloc::vec![value as u8]);
+    // Set the Observe flag
+    pub fn set_observe_flag(&mut self, value: ObserveOption) {
+        let value = match value {
+            ObserveOption::Register => alloc::vec![], // Value is not present if Register
+            ObserveOption::Deregister => alloc::vec![value as u8],
+        };
+        self.message.set_observe(value);
     }
 }
 


### PR DESCRIPTION
This is an implementation of the Observe RFC 7252 based on the one in [coap-rs/observe.rs](https://github.com/Covertness/coap-rs/blob/master/src/observer.rs) with some noticeable differences.

- Naming: I've used the official names from the RFC, which are Observer and Subject for the subscribing client and the struct holding the subscriptions for the resources. The original impl calls them "register" and "Observer".
- Simplified data structure: instead of having 3 maps for observers, subjects and (observer, resource) pairs, I've kept only one map `BTreeMap<ResourcePath, Resource<Endpoint>>`
- ACK behaviour
  -  afaik the original impl expects an ack for each notification message of a resource change. If the ack is not received it will poll a timer and repeat the notification until a limit of 10 times by default. Also an ack is accepted only if it has the same message id of the last message
  - my impl is simpler and thus also less complete. The lib user sends a notification only when there is an actual change in the resource and it keeps track of how many updates haven't received an ack yet. If the observer sends an ack with a matching token then the counter is reset. It doesn't matter if the message id is the same of the last notification, it's fine to receive an ack for some previous update. The packet could have been delayed in the network, but it means that the client is still interested in the resource. It also avoids the device sending multiple updates if the client is not answering.
- Scope: my impl doesn't handle packet handling and generation. It also doesn't store the state of the resources. It's just a struct to keep the state of the observers. Packet handling is done externally. As example for anyone interested in future, I've wrote an implementation of a simple Server which uses `smoltcp` [here](https://github.com/jiayihu/fedra-thesis/blob/351e9b1ff8/packages/fedra-iot/src/coap_server.rs#L19). The implementation could actually be moved here in future if someone else needs it.

@martindisch give me some more time to test the implementation but the initial tests are promising 😄 
