### PR TITLE
Implement the coap-mesage traits on request (after 16-bit option commit)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,13 @@ edition = "2018"
 doctest = false
 
 [dependencies]
+coap-message = { version = "0.1.0", optional = true }
 
 [features]
 default = ["std"]
 std = []
+
+with-coap-message = [ "coap-message" ]
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-coap-message = { version = "0.1.0", optional = true }
+coap-message = { version = "0.1.1", optional = true }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,22 @@ doctest = false
 [dependencies]
 coap-message = { version = "0.1.1", optional = true }
 
+# actually they are dev-dependencies, but those can't be optional
+coap-handler = { version = "0.0.2", optional = true }
+serde = { version = "*", default-features = false, features = [ "alloc" ], optional = true }
+coap-numbers = { version = "^0.1", optional = true }
+
 [features]
 default = ["std"]
 std = []
 
 with-coap-message = [ "coap-message" ]
 
+example-server_coaphandler = [ "with-coap-message", "coap-handler", "serde", "coap-numbers" ]
+
 [badges]
 maintenance = { status = "passively-maintained" }
+
+[[example]]
+name = "server_coaphandler"
+required-features = [ "example-server_coaphandler" ]

--- a/examples/server_coaphandler.rs
+++ b/examples/server_coaphandler.rs
@@ -1,0 +1,112 @@
+// Note that this example requires nightly for coap-handler's #![feature(iter_order_by)]
+
+use coap_lite::{CoapRequest, Packet};
+use std::net::UdpSocket;
+
+use serde::{Serialize, Deserialize};
+
+use coap_handler::implementations::{HandlerBuilder, TypedStaticResponse, SimpleCBORWrapper, SimpleCBORHandler, SimpleRenderable};
+use coap_handler::Handler as _;
+
+use coap_numbers;
+
+fn main() {
+    let mut value_at_cbor = StoredCBOR::new();
+
+    struct Time;
+
+    impl SimpleRenderable for Time {
+        fn render<W: core::fmt::Write>(&mut self, writer: &mut W) {
+            write!(writer, "It's {} seconds past epoch.",
+                   std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)
+                       .unwrap()
+                       .as_secs()
+                   ).unwrap();
+        }
+
+        fn content_format(&self) -> Option<u16> {
+            Some(0 /* text/plain */)
+        }
+    }
+
+    let mut handler = coap_handler::implementations::new_dispatcher()
+        .at(
+            &[".well-known", "core"],
+            TypedStaticResponse {
+                payload: b"</>,</time>,</cbor>",
+                contentformat: &[40],
+            },
+        )
+        .at(&[], "Welcome to the Demo server")
+        .at(&["time"], Time)
+        .at(&["cbor"], SimpleCBORWrapper::new(&mut value_at_cbor));
+
+    let socket = UdpSocket::bind("127.0.0.1:5683").unwrap();
+    let mut buf = [0; 1280];
+
+    loop {
+        let (size, src) =
+            socket.recv_from(&mut buf).expect("Didn't receive data");
+
+        let packet = Packet::from_bytes(&buf[..size]).unwrap();
+        let request = CoapRequest::from_packet(packet, src);
+
+        let extracted = handler.extract_request_data(&request.message);
+
+        let mut response = request.response.unwrap();
+        handler.build_response(&mut response.message, extracted);
+
+        let packet = response.message.to_bytes().unwrap();
+        socket
+            .send_to(&packet[..], &src)
+            .expect("Could not send the data");
+    }
+}
+
+// Just a more complex item for the list of resources
+
+#[derive(Serialize, Deserialize, Clone)]
+struct StoredCBOR {
+    hidden: bool,
+    number: usize,
+    label: String,
+    list: Vec<usize>,
+}
+
+impl StoredCBOR {
+    fn new() -> Self {
+        Self {
+            hidden: false,
+            number: 32,
+            label: "Hello".to_string(),
+            list: vec![1, 2, 3],
+        }
+    }
+}
+
+impl SimpleCBORHandler for &mut StoredCBOR {
+    type Get = StoredCBOR;
+    type Put = StoredCBOR;
+    type Post = StoredCBOR;
+
+    fn get(&mut self) -> Result<StoredCBOR, u8> {
+        if self.hidden {
+            return Err(coap_numbers::code::FORBIDDEN);
+        }
+        Ok(self.clone())
+    }
+
+    fn put(&mut self, new: &StoredCBOR) -> u8 {
+        if new.label.contains("<") {
+            // No HTML injection please ;-)
+            return coap_numbers::code::BAD_REQUEST;
+        }
+        **self = new.clone();
+        coap_numbers::code::CHANGED
+    }
+
+    fn post(&mut self, _: &StoredCBOR) -> u8 {
+        coap_numbers::code::METHOD_NOT_ALLOWED
+    }
+}
+

--- a/src/impl_coap_message.rs
+++ b/src/impl_coap_message.rs
@@ -104,6 +104,10 @@ impl MutableWritableMessage for Packet {
     fn payload_mut(&mut self) -> &mut [u8] {
         &mut self.payload
     }
+    fn payload_mut_with_len(&mut self, len: usize) -> &mut [u8] {
+        self.payload.resize(len, 0);
+        &mut self.payload
+    }
     fn truncate(&mut self, length: usize) {
         self.payload.truncate(length)
     }

--- a/src/impl_coap_message.rs
+++ b/src/impl_coap_message.rs
@@ -1,6 +1,6 @@
 use coap_message::{
     Code, MinimalWritableMessage, MutableWritableMessage, OptionNumber,
-    ReadableMessage,
+    ReadableMessage, SeekWritableMessage, WithSortedOptions,
 };
 
 use crate::{CoapOption, MessageClass, Packet};
@@ -76,6 +76,8 @@ impl<'a> ReadableMessage<'a> for Packet {
     }
 }
 
+impl<'a> WithSortedOptions<'a> for Packet {}
+
 impl OptionNumber for CoapOption {}
 
 impl MinimalWritableMessage for Packet {
@@ -116,3 +118,5 @@ impl MutableWritableMessage for Packet {
         }
     }
 }
+
+impl SeekWritableMessage for Packet {}

--- a/src/impl_coap_message.rs
+++ b/src/impl_coap_message.rs
@@ -1,0 +1,118 @@
+use coap_message::{
+    Code, MinimalWritableMessage, MutableWritableMessage, OptionNumber,
+    ReadableMessage,
+};
+
+use crate::{CoapOption, MessageClass, Packet};
+
+impl Code for MessageClass {
+    // Conveniently, it already satisfies the requirements
+}
+
+// pub only in name: We don't expose this whole module, so all users will know is that this is a
+// suitable iterator.
+pub struct MessageOptionAdapter<'a> {
+    head: Option<(u16, alloc::collections::linked_list::Iter<'a, Vec<u8>>)>,
+    // right from Packet::options -- fortunately that doesn't say that it returns an impl Iterator
+    raw_iter: alloc::collections::btree_map::Iter<
+        'a,
+        u16,
+        alloc::collections::linked_list::LinkedList<Vec<u8>>,
+    >,
+}
+
+// pub only in name: We don't expose this whole module, so all users will know is that this
+// implements coap_message::MessageOption
+pub struct MessageOption<'a> {
+    number: u16,
+    value: &'a [u8],
+}
+
+impl<'a> Iterator for MessageOptionAdapter<'a> {
+    type Item = MessageOption<'a>;
+
+    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
+        loop {
+            if let Some((number, values)) = self.head.as_mut() {
+                if let Some(value) = values.next() {
+                    return Some(MessageOption {
+                        number: *number,
+                        value,
+                    });
+                }
+            }
+            let (number, values) = self.raw_iter.next()?;
+            self.head = Some((*number, values.iter()));
+        }
+    }
+}
+
+impl<'a> coap_message::MessageOption for MessageOption<'a> {
+    fn number(&self) -> u16 {
+        self.number.into()
+    }
+    fn value(&self) -> &[u8] {
+        self.value
+    }
+}
+
+impl<'a> ReadableMessage<'a> for Packet {
+    type Code = MessageClass;
+
+    type MessageOption = MessageOption<'a>;
+    type OptionsIter = MessageOptionAdapter<'a>;
+
+    fn code(&self) -> Self::Code {
+        self.header.code
+    }
+    fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+    fn options(&'a self) -> Self::OptionsIter {
+        MessageOptionAdapter {
+            raw_iter: self.options(),
+            head: None,
+        }
+    }
+}
+
+impl OptionNumber for CoapOption {}
+
+impl MinimalWritableMessage for Packet {
+    type Code = MessageClass;
+    type OptionNumber = CoapOption;
+
+    fn set_code(&mut self, code: Self::Code) {
+        self.header.code = code;
+    }
+
+    fn add_option(&mut self, option: Self::OptionNumber, data: &[u8]) {
+        self.add_option(option, data.into());
+    }
+
+    fn set_payload(&mut self, payload: &[u8]) {
+        self.payload = payload.into();
+    }
+}
+
+impl MutableWritableMessage for Packet {
+    fn available_space(&self) -> usize {
+        usize::MAX
+    }
+    fn payload_mut(&mut self) -> &mut [u8] {
+        &mut self.payload
+    }
+    fn truncate(&mut self, length: usize) {
+        self.payload.truncate(length)
+    }
+    fn mutate_options<F>(&mut self, mut callback: F)
+    where
+        F: FnMut(Self::OptionNumber, &mut [u8]),
+    {
+        for (&number, ref mut values) in self.options.iter_mut() {
+            for v in values.iter_mut() {
+                callback(number.into(), v);
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,9 @@ mod packet;
 mod request;
 mod response;
 
+#[cfg(feature = "with-coap-message")]
+mod impl_coap_message;
+
 pub use header::{
     Header, HeaderRaw, MessageClass, MessageType, RequestType, ResponseType,
 };

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -202,7 +202,7 @@ impl From<ObserveOption> for usize {
 pub struct Packet {
     pub header: Header,
     token: Vec<u8>,
-    options: BTreeMap<u16, LinkedList<Vec<u8>>>,
+    pub(crate) options: BTreeMap<u16, LinkedList<Vec<u8>>>,
     pub payload: Vec<u8>,
 }
 


### PR DESCRIPTION
This is just #7 rebased onto the 16-bit-option branch, while removing what is now natively provided anyway.

By including the 16-bit option commit, this is semver incompatible.