### PR TITLE
Update optional dependency to coap-message 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-coap-message = { version = "0.1.1", optional = true }
+coap-message = { version = "^0.2.0-alpha.0", optional = true }
 
 # actually they are dev-dependencies, but those can't be optional
-coap-handler = { version = "0.0.2", optional = true }
+coap-handler = { version = "^0.1.0-alpha.0", optional = true }
 serde = { version = "1.0.123", default-features = false, features = ["alloc"], optional = true }
 coap-numbers = { version = "^0.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,13 @@ coap-message = { version = "^0.2.0-alpha.0", optional = true }
 
 # actually they are dev-dependencies, but those can't be optional
 coap-handler = { version = "^0.1.0-alpha.0", optional = true }
-serde = { version = "1.0.123", default-features = false, features = ["alloc"], optional = true }
-coap-numbers = { version = "^0.1", optional = true }
 
 [features]
 default = ["std"]
 std = []
 with-coap-message = ["coap-message"]
 
-example-server_coaphandler = ["with-coap-message", "coap-handler", "serde", "coap-numbers"]
+example-server_coaphandler = ["with-coap-message", "coap-handler"]
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/examples/server_coaphandler.rs
+++ b/examples/server_coaphandler.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use coap_handler::implementations::{
     HandlerBuilder, SimpleCBORHandler, SimpleCBORWrapper, SimpleRenderable,
-    TypedStaticResponse,
+    SimpleRendered, TypedStaticResponse,
 };
 use coap_handler::Handler as _;
 
@@ -44,8 +44,8 @@ fn main() {
                 contentformat: &[40],
             },
         )
-        .at(&[], "Welcome to the Demo server")
-        .at(&["time"], Time)
+        .at(&[], SimpleRendered("Welcome to the Demo server"))
+        .at(&["time"], SimpleRendered(Time))
         .at(&["cbor"], SimpleCBORWrapper::new(&mut value_at_cbor));
 
     let socket = UdpSocket::bind("127.0.0.1:5683").unwrap();

--- a/examples/server_coaphandler.rs
+++ b/examples/server_coaphandler.rs
@@ -1,52 +1,29 @@
-// Note that this example requires nightly for coap-handler's #![feature(iter_order_by)]
+/// This is a very simple example using the coap_message/_handler abstractions.
+///
+/// For an example that shows more advanced resources, see
+/// <https://gitlab.com/chrysn/coap-message-demos>, which has a coaplite example of its own, and
+/// features a much larger variety of interactive resources.
+///
+/// Note that this example requires nightly due to coap_handler's requirements.
 
 use coap_lite::{CoapRequest, Packet};
 use std::net::UdpSocket;
 
-use serde::{Deserialize, Serialize};
-
 use coap_handler::implementations::{
-    HandlerBuilder, SimpleCBORHandler, SimpleCBORWrapper, SimpleRenderable,
-    SimpleRendered, TypedStaticResponse,
+    HandlerBuilder, SimpleRendered, TypedStaticResponse,
 };
 use coap_handler::Handler as _;
 
-use coap_numbers;
-
 fn main() {
-    let mut value_at_cbor = StoredCBOR::new();
-
-    struct Time;
-
-    impl SimpleRenderable for Time {
-        fn render<W: core::fmt::Write>(&mut self, writer: &mut W) {
-            write!(
-                writer,
-                "It's {} seconds past epoch.",
-                std::time::SystemTime::now()
-                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs()
-            )
-            .unwrap();
-        }
-
-        fn content_format(&self) -> Option<u16> {
-            Some(0 /* text/plain */)
-        }
-    }
-
     let mut handler = coap_handler::implementations::new_dispatcher()
         .at(
             &[".well-known", "core"],
             TypedStaticResponse {
-                payload: b"</>,</time>,</cbor>",
+                payload: b"</>,</time>",
                 contentformat: &[40],
             },
         )
-        .at(&[], SimpleRendered("Welcome to the Demo server"))
-        .at(&["time"], SimpleRendered(Time))
-        .at(&["cbor"], SimpleCBORWrapper::new(&mut value_at_cbor));
+        .at(&[], SimpleRendered("Welcome to the Demo server"));
 
     let socket = UdpSocket::bind("127.0.0.1:5683").unwrap();
     let mut buf = [0; 1280];
@@ -67,52 +44,5 @@ fn main() {
         socket
             .send_to(&packet[..], &src)
             .expect("Could not send the data");
-    }
-}
-
-// Just a more complex item for the list of resources
-
-#[derive(Serialize, Deserialize, Clone)]
-struct StoredCBOR {
-    hidden: bool,
-    number: usize,
-    label: String,
-    list: Vec<usize>,
-}
-
-impl StoredCBOR {
-    fn new() -> Self {
-        Self {
-            hidden: false,
-            number: 32,
-            label: "Hello".to_string(),
-            list: vec![1, 2, 3],
-        }
-    }
-}
-
-impl SimpleCBORHandler for &mut StoredCBOR {
-    type Get = StoredCBOR;
-    type Put = StoredCBOR;
-    type Post = StoredCBOR;
-
-    fn get(&mut self) -> Result<StoredCBOR, u8> {
-        if self.hidden {
-            return Err(coap_numbers::code::FORBIDDEN);
-        }
-        Ok(self.clone())
-    }
-
-    fn put(&mut self, new: &StoredCBOR) -> u8 {
-        if new.label.contains("<") {
-            // No HTML injection please ;-)
-            return coap_numbers::code::BAD_REQUEST;
-        }
-        **self = new.clone();
-        coap_numbers::code::CHANGED
-    }
-
-    fn post(&mut self, _: &StoredCBOR) -> u8 {
-        coap_numbers::code::METHOD_NOT_ALLOWED
     }
 }

--- a/src/impl_coap_message.rs
+++ b/src/impl_coap_message.rs
@@ -56,11 +56,11 @@ impl<'a> coap_message::MessageOption for MessageOption<'a> {
     }
 }
 
-impl<'a> ReadableMessage<'a> for Packet {
+impl ReadableMessage for Packet {
     type Code = MessageClass;
 
-    type MessageOption = MessageOption<'a>;
-    type OptionsIter = MessageOptionAdapter<'a>;
+    type MessageOption<'a> = MessageOption<'a>;
+    type OptionsIter<'a> = MessageOptionAdapter<'a>;
 
     fn code(&self) -> Self::Code {
         self.header.code
@@ -68,15 +68,15 @@ impl<'a> ReadableMessage<'a> for Packet {
     fn payload(&self) -> &[u8] {
         &self.payload
     }
-    fn options(&'a self) -> Self::OptionsIter {
+    fn options<'a>(&'a self) -> Self::OptionsIter<'a> {
         MessageOptionAdapter {
-            raw_iter: self.options(),
+            raw_iter: (&self.options).iter(),
             head: None,
         }
     }
 }
 
-impl<'a> WithSortedOptions<'a> for Packet {}
+impl<'a> WithSortedOptions for Packet {}
 
 impl OptionNumber for CoapOption {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@
 //! [rust-async-coap]: https://github.com/google/rust-async-coap
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "with-coap-message", feature(generic_associated_types))]
 #![allow(clippy::needless_doctest_main)]
 
 #[macro_use]


### PR DESCRIPTION
The coap-message traits had to undergo a breaking transition in order to allow the implementation of composable message handlers.

As this affects a non-default feature (that, moreover, probably has not seen any uptake outside in my applications), it probably doesn't warrant a semver update.

---

By the way, now that https://gitlab.com/chrysn/coap-message-demos is out there, it may be worth considering a cutback on the example's features (with a pointer to "see X for all you can do with this"), especially since that includes an example based on coap-lite. If you want, I can add the changes here because the changes are related (in the sense that the update helps in doing the demos properly).