### PR TITLE
Add support for RFC8132 (FETCH/PATCH) methods and errors

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -119,6 +119,7 @@ impl From<u8> for MessageClass {
             0xA3 => MessageClass::Response(ResponseType::ServiceUnavailable),
             0xA4 => MessageClass::Response(ResponseType::GatewayTimeout),
             0xA5 => MessageClass::Response(ResponseType::ProxyingNotSupported),
+            0xA8 => MessageClass::Response(ResponseType::HopLimitReached),
             _ => MessageClass::Reserved,
         }
     }
@@ -171,6 +172,7 @@ impl From<MessageClass> for u8 {
             MessageClass::Response(ResponseType::ServiceUnavailable) => 0xA3,
             MessageClass::Response(ResponseType::GatewayTimeout) => 0xA4,
             MessageClass::Response(ResponseType::ProxyingNotSupported) => 0xA5,
+            MessageClass::Response(ResponseType::HopLimitReached) => 0xA8,
 
             _ => 0xFF,
         }
@@ -233,6 +235,7 @@ pub enum ResponseType {
     ServiceUnavailable,
     GatewayTimeout,
     ProxyingNotSupported,
+    HopLimitReached,
 
     UnKnown,
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -81,6 +81,9 @@ impl From<u8> for MessageClass {
             0x02 => MessageClass::Request(RequestType::Post),
             0x03 => MessageClass::Request(RequestType::Put),
             0x04 => MessageClass::Request(RequestType::Delete),
+            0x05 => MessageClass::Request(RequestType::Fetch),
+            0x06 => MessageClass::Request(RequestType::Patch),
+            0x07 => MessageClass::Request(RequestType::IPatch),
 
             0x41 => MessageClass::Response(ResponseType::Created),
             0x42 => MessageClass::Response(ResponseType::Deleted),
@@ -96,6 +99,7 @@ impl From<u8> for MessageClass {
             0x84 => MessageClass::Response(ResponseType::NotFound),
             0x85 => MessageClass::Response(ResponseType::MethodNotAllowed),
             0x86 => MessageClass::Response(ResponseType::NotAcceptable),
+            0x89 => MessageClass::Response(ResponseType::Conflict),
             0x8C => MessageClass::Response(ResponseType::PreconditionFailed),
             0x8D => {
                 MessageClass::Response(ResponseType::RequestEntityTooLarge)
@@ -106,6 +110,7 @@ impl From<u8> for MessageClass {
             0x88 => {
                 MessageClass::Response(ResponseType::RequestEntityIncomplete)
             }
+            0x96 => MessageClass::Response(ResponseType::UnprocessableEntity),
             0x9d => MessageClass::Response(ResponseType::TooManyRequests),
 
             0xA0 => MessageClass::Response(ResponseType::InternalServerError),
@@ -128,6 +133,9 @@ impl From<MessageClass> for u8 {
             MessageClass::Request(RequestType::Post) => 0x02,
             MessageClass::Request(RequestType::Put) => 0x03,
             MessageClass::Request(RequestType::Delete) => 0x04,
+            MessageClass::Request(RequestType::Fetch) => 0x05,
+            MessageClass::Request(RequestType::Patch) => 0x06,
+            MessageClass::Request(RequestType::IPatch) => 0x07,
 
             MessageClass::Response(ResponseType::Created) => 0x41,
             MessageClass::Response(ResponseType::Deleted) => 0x42,
@@ -143,6 +151,7 @@ impl From<MessageClass> for u8 {
             MessageClass::Response(ResponseType::NotFound) => 0x84,
             MessageClass::Response(ResponseType::MethodNotAllowed) => 0x85,
             MessageClass::Response(ResponseType::NotAcceptable) => 0x86,
+            MessageClass::Response(ResponseType::Conflict) => 0x89,
             MessageClass::Response(ResponseType::PreconditionFailed) => 0x8C,
             MessageClass::Response(ResponseType::RequestEntityTooLarge) => {
                 0x8D
@@ -153,6 +162,7 @@ impl From<MessageClass> for u8 {
             MessageClass::Response(ResponseType::RequestEntityIncomplete) => {
                 0x88
             }
+            MessageClass::Response(ResponseType::UnprocessableEntity) => 0x96,
             MessageClass::Response(ResponseType::TooManyRequests) => 0x9d,
 
             MessageClass::Response(ResponseType::InternalServerError) => 0xA0,
@@ -183,6 +193,9 @@ pub enum RequestType {
     Post,
     Put,
     Delete,
+    Fetch,
+    Patch,
+    IPatch,
     UnKnown,
 }
 
@@ -205,10 +218,12 @@ pub enum ResponseType {
     NotFound,
     MethodNotAllowed,
     NotAcceptable,
+    Conflict,
     PreconditionFailed,
     RequestEntityTooLarge,
     UnsupportedContentFormat,
     RequestEntityIncomplete,
+    UnprocessableEntity,
     TooManyRequests,
 
     // 500 Codes

--- a/src/request.rs
+++ b/src/request.rs
@@ -47,6 +47,9 @@ impl<Endpoint> CoapRequest<Endpoint> {
             MessageClass::Request(Method::Post) => &Method::Post,
             MessageClass::Request(Method::Put) => &Method::Put,
             MessageClass::Request(Method::Delete) => &Method::Delete,
+            MessageClass::Request(Method::Fetch) => &Method::Fetch,
+            MessageClass::Request(Method::Patch) => &Method::Patch,
+            MessageClass::Request(Method::IPatch) => &Method::IPatch,
             _ => &Method::UnKnown,
         }
     }
@@ -166,6 +169,9 @@ mod test {
         request.message.header.set_code("0.04");
         assert_eq!(&Method::Delete, request.get_method());
 
+        request.message.header.set_code("0.06");
+        assert_eq!(&Method::Patch, request.get_method());
+
         request.set_method(Method::Get);
         assert_eq!("0.01", request.message.header.get_code());
 
@@ -177,6 +183,9 @@ mod test {
 
         request.set_method(Method::Delete);
         assert_eq!("0.04", request.message.header.get_code());
+
+        request.set_method(Method::IPatch);
+        assert_eq!("0.07", request.message.header.get_code());
     }
 
     #[test]


### PR DESCRIPTION
Especially FETCH is crucial for OSCORE; the rest was added for completion (including Hop Limit Reached introduced in RFC8768).

(By the way, if you'd like to automate the process somewhat more, I'm keeping an up-to-date list [in the coap-numbers crate](https://gitlab.com/chrysn/coap-numbers/-/blob/master/src/code.rs#L152). With some macro magic, or additional data if anything is needed there, it should be well possible to avoid manual processes in more than one place).