### PR TITLE
Fix wrong check on observers retaintion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [dependencies]
 coap-message = { version = "^0.2.0-alpha.0", optional = true }
+log = { version = "0.4.14", default-features = false, optional = true }
 
 # actually they are dev-dependencies, but those can't be optional
 coap-handler = { version = "^0.1.0-alpha.0", optional = true }

--- a/LICENSE-3RD-PARTY
+++ b/LICENSE-3RD-PARTY
@@ -3,6 +3,7 @@ The MIT License
 
 applies to:
 - coap, Copyright (c) 2014-2016 Yang Zhang
+- log, Copyright (c) 2014 The Rust Project Developers
 -------------------------------------------------------------------------------
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -28,6 +29,7 @@ The Apache License
 
 applies to:
 - rust-async-coap
+- log
 -------------------------------------------------------------------------------
                                  Apache License
                            Version 2.0, January 2004

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,8 @@ pub mod error;
 
 mod header;
 pub mod link_format;
+#[macro_use]
+mod log;
 mod observe;
 mod packet;
 mod request;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ mod impl_coap_message;
 pub use header::{
     Header, HeaderRaw, MessageClass, MessageType, RequestType, ResponseType,
 };
-pub use observe::Subject;
+pub use observe::{create_notification, Subject};
 pub use packet::{CoapOption, ContentFormat, ObserveOption, Packet};
 pub use request::CoapRequest;
 pub use response::CoapResponse;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,19 @@
+#[cfg(feature = "log")]
+macro_rules! coap_log {
+    (info, $($arg:expr),*) => { log::info!($($arg),*); };
+    (debug, $($arg:expr),*) => { log::debug!($($arg),*); };
+}
+
+#[cfg(not(feature = "log"))]
+#[macro_use]
+macro_rules! coap_log {
+    ($level:ident, $($arg:expr),*) => { $( let _ = $arg; )* }
+}
+
+macro_rules! coap_info {
+    ($($arg:expr),*) => (coap_log!(info, $($arg),*));
+}
+
+macro_rules! coap_debug {
+    ($($arg:expr),*) => (coap_log!(debug, $($arg),*));
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -5,7 +5,6 @@ macro_rules! coap_log {
 }
 
 #[cfg(not(feature = "log"))]
-#[macro_use]
 macro_rules! coap_log {
     ($level:ident, $($arg:expr),*) => { $( let _ = $arg; )* }
 }

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -5,6 +5,8 @@ use alloc::{
 };
 use core::{fmt::Display, marker::PhantomData};
 
+use crate::{MessageClass, MessageType, Packet};
+
 use super::request::CoapRequest;
 
 const DEFAULT_UNACKNOWLEDGED_LIMIT: u8 = 10;
@@ -16,6 +18,8 @@ pub struct Observer<Endpoint: Display> {
     pub endpoint: Endpoint,
     pub token: Vec<u8>,
     unacknowledged_messages: u8,
+    // The message id of the last update to be acknowledged
+    message_id: Option<u16>,
 }
 
 /// An observed resource.
@@ -28,6 +32,7 @@ pub struct Resource<Endpoint: Display> {
 pub struct Subject<Endpoint: Display + PartialEq> {
     resources: BTreeMap<ResourcePath, Resource<Endpoint>>,
     unacknowledged_limit: u8,
+    // The Endpoint generic is needed internally for CoapRequest, but not for this struct fields
     phantom: PhantomData<Endpoint>,
 }
 
@@ -42,6 +47,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
             endpoint: observer_endpoint.clone(),
             token: token.clone(),
             unacknowledged_messages: 0,
+            message_id: None,
         };
 
         let resource =
@@ -82,7 +88,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
     ///
     /// It increments the resource sequence and counter of unacknowledged
     /// updates.
-    pub fn resource_changed(&mut self, resource: &str) {
+    pub fn resource_changed(&mut self, resource: &str, message_id: u16) {
         let unacknowledged_limit = self.unacknowledged_limit;
 
         self.resources
@@ -92,10 +98,13 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
 
                 resource.observers.iter_mut().for_each(|observer| {
                     observer.unacknowledged_messages += 1;
+                    observer.message_id = Some(message_id);
                 });
 
                 resource.observers.retain(|observer| {
-                    observer.unacknowledged_messages <= unacknowledged_limit
+                    observer.message_id.is_some()
+                        && observer.unacknowledged_messages
+                            <= unacknowledged_limit
                 });
             });
     }
@@ -103,16 +112,23 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
     /// Resets the counter of unacknowledged updates for a resource observer.
     pub fn acknowledge(&mut self, request: &CoapRequest<Endpoint>) {
         let observer_endpoint = request.source.as_ref().unwrap();
-        let resource_path = request.get_path();
-        let token = request.message.get_token();
+        let message_id = request.message.header.message_id;
 
-        if let Some(resource) = self.resources.get_mut(&resource_path) {
+        for (_resource_path, resource) in self.resources.iter_mut() {
             let observer = resource.observers.iter_mut().find(|x| {
-                x.endpoint == *observer_endpoint && x.token == *token
+                if let Some(observe_msg_id) = x.message_id {
+                    // Unacknowledgement doesn't officially require the token to be passed in the ACK
+                    // so it's not checked
+                    return x.endpoint == *observer_endpoint
+                        && observe_msg_id == message_id;
+                }
+
+                return false;
             });
 
             if let Some(observer) = observer {
                 observer.unacknowledged_messages = 0;
+                observer.message_id = None;
             }
         }
     }
@@ -136,6 +152,32 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
     pub fn set_unacknowledged_limit(&mut self, limit: u8) {
         self.unacknowledged_limit = limit;
     }
+}
+
+pub fn create_notification(
+    message_id: u16,
+    token: Vec<u8>,
+    sequence: u32,
+    payload: Vec<u8>,
+) -> Packet {
+    let mut packet = Packet::new();
+
+    packet.header.set_version(1);
+    packet.header.set_type(MessageType::Confirmable);
+    packet.header.code = MessageClass::Response(crate::ResponseType::Content);
+    packet.header.message_id = message_id;
+    packet.set_token(token);
+    packet.payload = payload;
+
+    let mut sequence_bytes = sequence.to_be_bytes().to_vec();
+    let first_non_zero = sequence_bytes
+        .iter()
+        .position(|&x| x > 0)
+        .unwrap_or(sequence_bytes.len());
+    sequence_bytes.drain(0..first_non_zero);
+    packet.set_observe(sequence_bytes);
+
+    packet
 }
 
 impl<Endpoint: Display + PartialEq + Clone> Default for Subject<Endpoint> {
@@ -237,7 +279,7 @@ mod test {
         subject.register(&request1);
 
         let sequence1 = subject.get_resource(resource_path).unwrap().sequence;
-        subject.resource_changed(resource_path);
+        subject.resource_changed(resource_path, 1);
         let sequence2 = subject.get_resource(resource_path).unwrap().sequence;
 
         assert!(sequence2 > sequence1);
@@ -256,6 +298,7 @@ mod test {
         ack.message.header.set_type(MessageType::Acknowledgement);
         ack.set_path(resource_path.clone());
         ack.message.set_token(vec![0x00, 0x00]);
+        ack.message.header.message_id = 1;
 
         subject.acknowledge(&ack);
 
@@ -286,12 +329,12 @@ mod test {
         subject.set_unacknowledged_limit(5);
         subject.register(&request1);
 
-        subject.resource_changed(resource_path);
-        subject.resource_changed(resource_path);
-        subject.resource_changed(resource_path);
-        subject.resource_changed(resource_path);
-        subject.resource_changed(resource_path);
-        subject.resource_changed(resource_path);
+        subject.resource_changed(resource_path, 1);
+        subject.resource_changed(resource_path, 2);
+        subject.resource_changed(resource_path, 3);
+        subject.resource_changed(resource_path, 4);
+        subject.resource_changed(resource_path, 5);
+        subject.resource_changed(resource_path, 6);
 
         let observers = subject
             .get_resource_observers(resource_path.clone())

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -50,6 +50,12 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
             message_id: None,
         };
 
+        coap_info!(
+            "Registering observer {} for resource {}",
+            observer_endpoint,
+            resource_path
+        );
+
         let resource =
             self.resources.entry(resource_path).or_insert(Resource {
                 observers: Vec::new(),
@@ -79,6 +85,12 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
             });
 
             if let Some(position) = position {
+                coap_info!(
+                    "Deregistering observer {} for resource {}",
+                    observer_endpoint,
+                    resource_path
+                );
+
                 resource.observers.remove(position);
             }
         }
@@ -114,7 +126,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
         let observer_endpoint = request.source.as_ref().unwrap();
         let message_id = request.message.header.message_id;
 
-        for (_resource_path, resource) in self.resources.iter_mut() {
+        for (resource_path, resource) in self.resources.iter_mut() {
             let observer = resource.observers.iter_mut().find(|x| {
                 if let Some(observe_msg_id) = x.message_id {
                     // Unacknowledgement doesn't officially require the token to be passed in the ACK
@@ -127,6 +139,8 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
             });
 
             if let Some(observer) = observer {
+                coap_debug!("Received ack for resource {}", resource_path);
+
                 observer.unacknowledged_messages = 0;
                 observer.message_id = None;
             }

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -102,6 +102,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
     /// updates.
     pub fn resource_changed(&mut self, resource: &str, message_id: u16) {
         let unacknowledged_limit = self.unacknowledged_limit;
+        coap_debug!("Resource changed");
 
         self.resources
             .entry(resource.to_string())
@@ -114,9 +115,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
                 });
 
                 resource.observers.retain(|observer| {
-                    observer.message_id.is_some()
-                        && observer.unacknowledged_messages
-                            <= unacknowledged_limit
+                    observer.unacknowledged_messages <= unacknowledged_limit
                 });
             });
     }

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -30,7 +30,8 @@ pub struct Resource<Endpoint: Display> {
 pub struct Subject<Endpoint: Display + PartialEq> {
     resources: BTreeMap<ResourcePath, Resource<Endpoint>>,
     unacknowledged_limit: u8,
-    // The Endpoint generic is needed internally for CoapRequest, but not for this struct fields
+    // The Endpoint generic is needed internally for CoapRequest, but not as an
+    // actual field for this struct
     phantom: PhantomData<Endpoint>,
 }
 
@@ -165,6 +166,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
     }
 }
 
+/// Creates a notification response for notifying observers about an update.
 pub fn create_notification(
     message_id: u16,
     token: Vec<u8>,

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -5,9 +5,7 @@ use alloc::{
 };
 use core::{fmt::Display, marker::PhantomData};
 
-use crate::{MessageClass, MessageType, Packet};
-
-use super::request::CoapRequest;
+use super::{request::CoapRequest, MessageClass, MessageType, Packet};
 
 const DEFAULT_UNACKNOWLEDGED_LIMIT: u8 = 10;
 

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -133,7 +133,7 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
                         && observe_msg_id == message_id;
                 }
 
-                return false;
+                false
             });
 
             if let Some(observer) = observer {


### PR DESCRIPTION
I actually had this commits for a long while, but wanted to check to be sure it worked correctly, then forgot to ever open the PR.

- It adds the `log` feature to help with debugging
- It adds the `create_notification` method to create the packet which notifies observers about an update
- It corrects the ack check, ensuring that the ack corresponds to the last notification and not for some old one