### PR TITLE
Improve safety and correctness of option value type handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -87,3 +87,6 @@ impl fmt::Display for IncompatibleOptionValueFormat {
         write!(f, "Incompatible option value: {}", self.message)
     }
 }
+
+#[cfg(feature = "std")]
+impl error::Error for IncompatibleOptionValueFormat {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 //! The errors of the `coap` module.
 
+use alloc::string::String;
 use core::fmt;
 #[cfg(feature = "std")]
 use std::error;

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,3 +76,14 @@ impl error::Error for InvalidObserve {
         None
     }
 }
+
+#[derive(Debug, PartialEq)]
+pub struct IncompatibleOptionValueFormat {
+    pub(crate) message: String,
+}
+
+impl fmt::Display for IncompatibleOptionValueFormat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Incompatible option value: {}", self.message)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,7 @@ impl fmt::Display for InvalidObserve {
 #[cfg(feature = "std")]
 impl error::Error for InvalidObserve {}
 
+/// The error that can occur when parsing an option value.
 #[derive(Debug, PartialEq)]
 pub struct IncompatibleOptionValueFormat {
     pub(crate) message: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,11 +37,7 @@ impl fmt::Display for MessageError {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for MessageError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        None
-    }
-}
+impl error::Error for MessageError {}
 
 /// The error that can occur when parsing a content-format.
 #[derive(Debug, PartialEq)]
@@ -54,11 +50,7 @@ impl fmt::Display for InvalidContentFormat {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for InvalidContentFormat {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        None
-    }
-}
+impl error::Error for InvalidContentFormat {}
 
 /// The error that can occur when parsing an observe option value.
 #[derive(Debug, PartialEq)]
@@ -71,11 +63,7 @@ impl fmt::Display for InvalidObserve {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for InvalidObserve {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        None
-    }
-}
+impl error::Error for InvalidObserve {}
 
 #[derive(Debug, PartialEq)]
 pub struct IncompatibleOptionValueFormat {

--- a/src/impl_coap_message.rs
+++ b/src/impl_coap_message.rs
@@ -13,7 +13,8 @@ impl Code for MessageClass {
 // is that this is a suitable iterator.
 pub struct MessageOptionAdapter<'a> {
     head: Option<(u16, alloc::collections::linked_list::Iter<'a, Vec<u8>>)>,
-    // right from Packet::options -- fortunately that doesn't say that it returns an impl Iterator
+    // right from Packet::options -- fortunately that doesn't say that it
+    // returns an impl Iterator
     raw_iter: alloc::collections::btree_map::Iter<
         'a,
         u16,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub mod link_format;
 #[macro_use]
 mod log;
 mod observe;
-mod option_value;
+pub mod option_value;
 mod packet;
 mod request;
 mod response;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,8 @@ pub mod link_format;
 #[macro_use]
 mod log;
 mod observe;
-mod packet;
 mod option_value;
+mod packet;
 mod request;
 mod response;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ pub mod link_format;
 mod log;
 mod observe;
 mod packet;
+mod option_value;
 mod request;
 mod response;
 

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -127,8 +127,8 @@ impl<Endpoint: Display + PartialEq + Clone> Subject<Endpoint> {
         for (resource_path, resource) in self.resources.iter_mut() {
             let observer = resource.observers.iter_mut().find(|x| {
                 if let Some(observe_msg_id) = x.message_id {
-                    // Unacknowledgement doesn't officially require the token to be passed in the ACK
-                    // so it's not checked
+                    // Unacknowledgement doesn't officially require the token
+                    // to be passed in the ACK so it's not checked
                     return x.endpoint == *observer_endpoint
                         && observe_msg_id == message_id;
                 }

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -182,14 +182,7 @@ pub fn create_notification(
     packet.set_token(token);
     packet.payload = payload;
 
-    let mut sequence_bytes = sequence.to_be_bytes().to_vec();
-    let first_non_zero = sequence_bytes
-        .iter()
-        .position(|&x| x > 0)
-        .unwrap_or(sequence_bytes.len());
-    sequence_bytes.drain(0..first_non_zero);
-    packet.set_observe(sequence_bytes);
-
+    packet.set_observe_value(sequence);
     packet
 }
 
@@ -224,9 +217,7 @@ mod test {
         request.set_method(Method::Get);
         request.set_path(resource_path.clone());
         request.message.set_token(vec![0x7d, 0x34]);
-        request
-            .message
-            .set_observe(vec![ObserveOption::Register as u8]);
+        request.set_observe_flag(ObserveOption::Register);
 
         let mut subject: Subject<Endpoint> = Subject::default();
         subject.register(&request);
@@ -247,18 +238,14 @@ mod test {
         request1.set_method(Method::Get);
         request1.set_path(resource_path.clone());
         request1.message.set_token(vec![0x00, 0x00]);
-        request1
-            .message
-            .set_observe(vec![ObserveOption::Register as u8]);
+        request1.set_observe_flag(ObserveOption::Register);
 
         let mut request2 = CoapRequest::new();
         request2.source = Some(String::from("0.0.0.0"));
         request2.set_method(Method::Get);
         request2.set_path(resource_path.clone());
         request2.message.set_token(vec![0xff, 0xff]);
-        request2
-            .message
-            .set_observe(vec![ObserveOption::Register as u8]);
+        request2.set_observe_flag(ObserveOption::Register);
 
         let mut subject: Subject<Endpoint> = Subject::default();
         subject.register(&request1);
@@ -284,9 +271,7 @@ mod test {
         request1.set_method(Method::Get);
         request1.set_path(resource_path.clone());
         request1.message.set_token(vec![0x00, 0x00]);
-        request1
-            .message
-            .set_observe(vec![ObserveOption::Register as u8]);
+        request1.set_observe_flag(ObserveOption::Register);
 
         let mut subject: Subject<Endpoint> = Subject::default();
         subject.register(&request1);
@@ -334,9 +319,7 @@ mod test {
         request1.set_method(Method::Get);
         request1.set_path(resource_path.clone());
         request1.message.set_token(vec![0x00, 0x00]);
-        request1
-            .message
-            .set_observe(vec![ObserveOption::Register as u8]);
+        request1.set_observe_flag(ObserveOption::Register);
 
         let mut subject: Subject<Endpoint> = Subject::default();
         subject.set_unacknowledged_limit(5);

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -181,8 +181,8 @@ pub fn create_notification(
     packet.header.message_id = message_id;
     packet.set_token(token);
     packet.payload = payload;
-
     packet.set_observe_value(sequence);
+
     packet
 }
 

--- a/src/option_value.rs
+++ b/src/option_value.rs
@@ -49,6 +49,7 @@ fn option_from_uint(value_as_u64: u64, value_size: usize) -> Vec<u8> {
 
         // Output is in little endian, flip it to big endian (network order) as required
         output.reverse();
+
         output
     }
 }

--- a/src/option_value.rs
+++ b/src/option_value.rs
@@ -15,9 +15,9 @@ macro_rules! option_value_uint_impl {
         #[derive(Debug, Clone, PartialEq)]
         pub struct $struct_name(pub $type);
 
-        impl Into<Vec<u8>> for $struct_name {
-            fn into(self) -> Vec<u8> {
-                option_from_uint(self.0.into(), $bytes)
+        impl From<$struct_name> for Vec<u8> {
+            fn from(value: $struct_name) -> Self {
+                option_from_uint(value.0.into(), $bytes)
             }
         }
 
@@ -62,7 +62,7 @@ fn option_from_uint(value_as_u64: u64, value_size: usize) -> Vec<u8> {
 }
 
 fn option_to_uint(
-    encoded: &Vec<u8>,
+    encoded: &[u8],
     value_size: usize,
 ) -> Result<u64, IncompatibleOptionValueFormat> {
     if encoded.len() > value_size {
@@ -86,9 +86,9 @@ option_value_uint_impl!(OptionValueU64, u64, 8);
 #[derive(Debug, Clone, PartialEq)]
 pub struct OptionValueString(pub String);
 
-impl Into<Vec<u8>> for OptionValueString {
-    fn into(self) -> Vec<u8> {
-        self.0.into_bytes()
+impl From<OptionValueString> for Vec<u8> {
+    fn from(option_value: OptionValueString) -> Self {
+        option_value.0.into_bytes()
     }
 }
 
@@ -97,7 +97,7 @@ impl TryFrom<Vec<u8>> for OptionValueString {
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         String::from_utf8(value)
-            .map(|s| OptionValueString(s))
+            .map(OptionValueString)
             .map_err(|e| IncompatibleOptionValueFormat {
                 message: e.to_string(),
             })

--- a/src/option_value.rs
+++ b/src/option_value.rs
@@ -1,3 +1,5 @@
+//! Convenience types for option values.
+
 use crate::error::IncompatibleOptionValueFormat;
 use alloc::{
     string::{String, ToString},
@@ -5,6 +7,7 @@ use alloc::{
 };
 use core::convert::TryFrom;
 
+/// Supertrait for types that can be used as option values.
 pub trait OptionValueType:
     Into<Vec<u8>> + TryFrom<Vec<u8>, Error = IncompatibleOptionValueFormat>
 {

--- a/src/option_value.rs
+++ b/src/option_value.rs
@@ -22,7 +22,8 @@ macro_rules! option_value_uint_impl {
 
             fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
                 option_to_uint(&value, $bytes)
-                    // Safe because option_to_uint will yield error if the size would overflow
+                    // Safe because option_to_uint will yield error if the size
+                    // would overflow
                     .map(|value_as_u64| $struct_name(value_as_u64 as $type))
             }
         }
@@ -48,7 +49,8 @@ fn option_from_uint(value_as_u64: u64, value_size: usize) -> Vec<u8> {
             draining_value >>= 8;
         }
 
-        // Output is in little endian, flip it to big endian (network order) as required
+        // Output is in little endian, flip it to big endian (network order) as
+        // required
         output.reverse();
 
         output

--- a/src/option_value.rs
+++ b/src/option_value.rs
@@ -1,0 +1,91 @@
+use core::convert::TryFrom;
+use crate::error::IncompatibleOptionValueFormat;
+
+pub trait OptionValueType: Into<Vec<u8>> + TryFrom<Vec<u8>, Error=IncompatibleOptionValueFormat> {
+}
+
+macro_rules! option_value_uint_impl {
+    ($struct_name:ident, $type:ty, $bytes:expr) => {
+        #[derive(Debug, Clone, PartialEq)]
+        pub struct $struct_name(pub $type);
+
+        impl Into<Vec<u8>> for $struct_name {
+            fn into(self) -> Vec<u8> {
+                option_from_uint(self.0.into(), $bytes)
+            }
+        }
+
+        impl TryFrom<Vec<u8>> for $struct_name {
+            type Error = IncompatibleOptionValueFormat;
+
+            fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+                option_to_uint(&value, $bytes)
+                    // Safe because option_to_uint will yield error if the size would overflow
+                    .map(|value_as_u64| $struct_name(value_as_u64 as $type))
+            }
+        }
+
+        impl OptionValueType for $struct_name {
+        }
+    }
+}
+
+fn option_from_uint(value_as_u64: u64, value_size: usize) -> Vec<u8> {
+    // Optimize common paths
+    if value_as_u64 == 0 {
+        vec![]
+    } else if value_as_u64 < 256 {
+        vec![value_as_u64 as u8]
+    } else {
+        let mut draining_value = value_as_u64;
+
+        let mut output = Vec::with_capacity(value_size);
+        while draining_value > 0 {
+            let next_lowest_byte = (draining_value & 0xff) as u8;
+            assert!(output.len() < value_size);
+            output.push(next_lowest_byte);
+            draining_value >>= 8;
+        }
+
+        // Output is in little endian, flip it to big endian (network order) as required
+        output.reverse();
+        output
+    }
+}
+
+fn option_to_uint(encoded: &Vec<u8>, value_size: usize) -> Result<u64, IncompatibleOptionValueFormat> {
+    if encoded.len() > value_size {
+        Err(IncompatibleOptionValueFormat {
+            message: format!("overflow: got {} bytes, expected {}", encoded.len(), value_size)
+        })
+    } else {
+        Ok(encoded.iter().fold(0, |acc, &b| (acc << 8) + b as u64))
+    }
+}
+
+option_value_uint_impl!(OptionValueU8, u8, 1);
+option_value_uint_impl!(OptionValueU16, u16, 2);
+option_value_uint_impl!(OptionValueU32, u32, 4);
+option_value_uint_impl!(OptionValueU64, u64, 8);
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OptionValueString(pub String);
+
+impl Into<Vec<u8>> for OptionValueString {
+    fn into(self) -> Vec<u8> {
+        self.0.into_bytes()
+    }
+}
+
+impl TryFrom<Vec<u8>> for OptionValueString {
+    type Error = IncompatibleOptionValueFormat;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        String::from_utf8(value)
+            .map(|s| OptionValueString(s))
+            .map_err(|e| IncompatibleOptionValueFormat { message: e.to_string() })
+    }
+}
+
+impl OptionValueType for OptionValueString {
+}

--- a/src/option_value.rs
+++ b/src/option_value.rs
@@ -1,4 +1,8 @@
 use crate::error::IncompatibleOptionValueFormat;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::convert::TryFrom;
 
 pub trait OptionValueType:

--- a/src/option_value.rs
+++ b/src/option_value.rs
@@ -1,7 +1,9 @@
-use core::convert::TryFrom;
 use crate::error::IncompatibleOptionValueFormat;
+use core::convert::TryFrom;
 
-pub trait OptionValueType: Into<Vec<u8>> + TryFrom<Vec<u8>, Error=IncompatibleOptionValueFormat> {
+pub trait OptionValueType:
+    Into<Vec<u8>> + TryFrom<Vec<u8>, Error = IncompatibleOptionValueFormat>
+{
 }
 
 macro_rules! option_value_uint_impl {
@@ -25,9 +27,8 @@ macro_rules! option_value_uint_impl {
             }
         }
 
-        impl OptionValueType for $struct_name {
-        }
-    }
+        impl OptionValueType for $struct_name {}
+    };
 }
 
 fn option_from_uint(value_as_u64: u64, value_size: usize) -> Vec<u8> {
@@ -54,10 +55,17 @@ fn option_from_uint(value_as_u64: u64, value_size: usize) -> Vec<u8> {
     }
 }
 
-fn option_to_uint(encoded: &Vec<u8>, value_size: usize) -> Result<u64, IncompatibleOptionValueFormat> {
+fn option_to_uint(
+    encoded: &Vec<u8>,
+    value_size: usize,
+) -> Result<u64, IncompatibleOptionValueFormat> {
     if encoded.len() > value_size {
         Err(IncompatibleOptionValueFormat {
-            message: format!("overflow: got {} bytes, expected {}", encoded.len(), value_size)
+            message: format!(
+                "overflow: got {} bytes, expected {}",
+                encoded.len(),
+                value_size
+            ),
         })
     } else {
         Ok(encoded.iter().fold(0, |acc, &b| (acc << 8) + b as u64))
@@ -84,9 +92,10 @@ impl TryFrom<Vec<u8>> for OptionValueString {
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         String::from_utf8(value)
             .map(|s| OptionValueString(s))
-            .map_err(|e| IncompatibleOptionValueFormat { message: e.to_string() })
+            .map_err(|e| IncompatibleOptionValueFormat {
+                message: e.to_string(),
+            })
     }
 }
 
-impl OptionValueType for OptionValueString {
-}
+impl OptionValueType for OptionValueString {}

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -612,6 +612,8 @@ impl Packet {
 
 #[cfg(test)]
 mod test {
+    use alloc::borrow::ToOwned;
+
     use super::{super::header, *};
     use crate::option_value::OptionValueString;
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -241,7 +241,7 @@ impl Packet {
     }
 
     /// Sets an option's values using a structured option value format.
-    pub fn set_option_as<T: OptionValueType>(
+    pub fn set_options_as<T: OptionValueType>(
         &mut self,
         tp: CoapOption,
         value: LinkedList<T>,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -256,7 +256,8 @@ impl Packet {
         self.options.get(&tp.into())
     }
 
-    /// Returns an option's values all decoded using the specified structured option value format.
+    /// Returns an option's values all decoded using the specified structured
+    /// option value format.
     pub fn get_options_as<T: OptionValueType>(
         &self,
         tp: CoapOption,
@@ -269,20 +270,23 @@ impl Packet {
         })
     }
 
-    /// Returns an option's first value as a convenience when only one is expected.
+    /// Returns an option's first value as a convenience when only one is
+    /// expected.
     pub fn get_first_option(&self, tp: CoapOption) -> Option<&Vec<u8>> {
         self.options
             .get(&tp.into())
             .and_then(|options| options.front())
     }
 
-    /// Returns an option's first value as a convenience when only one is expected.
+    /// Returns an option's first value as a convenience when only one is
+    /// expected.
     pub fn get_first_option_as<T: OptionValueType>(
         &self,
         tp: CoapOption,
     ) -> Option<Result<T, IncompatibleOptionValueFormat>> {
-        // TODO: We only need a clone() of the value for string and opaque types but it's not clear to me how
-        // to express this in OptionValueType
+        // TODO: We only need a clone() of the value for string and opaque
+        // types but it's not clear to me how to express this in
+        // OptionValueType
         self.get_first_option(tp)
             .map(|value| T::try_from(value.clone()))
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -240,38 +240,6 @@ impl Packet {
         self.options.insert(tp.into(), value);
     }
 
-    /// Returns an option's first value as a convenience when only one is expected.
-    pub fn get_first_option(&self, tp: CoapOption) -> Option<&Vec<u8>> {
-        self.options
-            .get(&tp.into())
-            .and_then(|options| options.front())
-    }
-
-    /// Returns an option's values.
-    pub fn get_option(&self, tp: CoapOption) -> Option<&LinkedList<Vec<u8>>> {
-        self.options.get(&tp.into())
-    }
-
-    /// Adds an option value.
-    pub fn add_option(&mut self, tp: CoapOption, value: Vec<u8>) {
-        let num = tp.into();
-        if let Some(list) = self.options.get_mut(&num) {
-            list.push_back(value);
-            return;
-        }
-
-        let mut list = LinkedList::new();
-        list.push_back(value);
-        self.options.insert(num, list);
-    }
-
-    /// Removes an option.
-    pub fn clear_option(&mut self, tp: CoapOption) {
-        if let Some(list) = self.options.get_mut(&tp.into()) {
-            list.clear()
-        }
-    }
-
     /// Sets an option's values using a structured option value format.
     pub fn set_option_as<T: OptionValueType>(
         &mut self,
@@ -283,15 +251,9 @@ impl Packet {
         self.set_option(tp, raw_value);
     }
 
-    /// Returns an option's first value as a convenience when only one is expected.
-    pub fn get_first_option_as<T: OptionValueType>(
-        &self,
-        tp: CoapOption,
-    ) -> Option<Result<T, IncompatibleOptionValueFormat>> {
-        // TODO: We only need a clone() of the value for string and opaque types but it's not clear to me how
-        // to express this in OptionValueType
-        self.get_first_option(tp)
-            .map(|value| T::try_from(value.clone()))
+    /// Returns an option's values.
+    pub fn get_option(&self, tp: CoapOption) -> Option<&LinkedList<Vec<u8>>> {
+        self.options.get(&tp.into())
     }
 
     /// Returns an option's values all decoded using the specified structured option value format.
@@ -307,6 +269,37 @@ impl Packet {
         })
     }
 
+    /// Returns an option's first value as a convenience when only one is expected.
+    pub fn get_first_option(&self, tp: CoapOption) -> Option<&Vec<u8>> {
+        self.options
+            .get(&tp.into())
+            .and_then(|options| options.front())
+    }
+
+    /// Returns an option's first value as a convenience when only one is expected.
+    pub fn get_first_option_as<T: OptionValueType>(
+        &self,
+        tp: CoapOption,
+    ) -> Option<Result<T, IncompatibleOptionValueFormat>> {
+        // TODO: We only need a clone() of the value for string and opaque types but it's not clear to me how
+        // to express this in OptionValueType
+        self.get_first_option(tp)
+            .map(|value| T::try_from(value.clone()))
+    }
+
+    /// Adds an option value.
+    pub fn add_option(&mut self, tp: CoapOption, value: Vec<u8>) {
+        let num = tp.into();
+        if let Some(list) = self.options.get_mut(&num) {
+            list.push_back(value);
+            return;
+        }
+
+        let mut list = LinkedList::new();
+        list.push_back(value);
+        self.options.insert(num, list);
+    }
+
     /// Adds an option value using a structured option value format.
     pub fn add_option_as<T: OptionValueType>(
         &mut self,
@@ -314,6 +307,13 @@ impl Packet {
         value: T,
     ) {
         self.add_option(tp, value.into());
+    }
+
+    /// Removes an option.
+    pub fn clear_option(&mut self, tp: CoapOption) {
+        if let Some(list) = self.options.get_mut(&tp.into()) {
+            list.clear()
+        }
     }
 
     /// Sets the content-format.

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -246,8 +246,7 @@ impl Packet {
         tp: CoapOption,
         value: LinkedList<T>,
     ) {
-        let raw_value: LinkedList<Vec<u8>> =
-            value.into_iter().map(|x| x.into()).collect();
+        let raw_value = value.into_iter().map(|x| x.into()).collect();
         self.set_option(tp, raw_value);
     }
 
@@ -266,7 +265,7 @@ impl Packet {
             options
                 .iter()
                 .map(|raw_value| T::try_from(raw_value.clone()))
-                .collect::<LinkedList<_>>()
+                .collect()
         })
     }
 
@@ -810,10 +809,7 @@ mod test {
         for &value in &values {
             p.add_option_as(option_key, OptionValueU32(value));
         }
-        let expected = values
-            .iter()
-            .map(|&x| Ok(OptionValueU32(x)))
-            .collect::<LinkedList<_>>();
+        let expected = values.iter().map(|&x| Ok(OptionValueU32(x))).collect();
         let actual = p.get_options_as::<OptionValueU32>(option_key);
         assert_eq!(actual, Some(expected));
     }
@@ -829,7 +825,7 @@ mod test {
         let expected = values
             .iter()
             .map(|&x| Ok(OptionValueString(x.to_owned())))
-            .collect::<LinkedList<_>>();
+            .collect();
         let actual = p.get_options_as::<OptionValueString>(option_key);
         assert_eq!(actual, Some(expected));
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -333,18 +333,6 @@ impl Packet {
             .and_then(|value| ContentFormat::try_from(value).ok())
     }
 
-    #[deprecated(note = "please use `set_observe_value` instead")]
-    pub fn set_observe(&mut self, value: Vec<u8>) {
-        self.clear_option(CoapOption::Observe);
-        self.add_option(CoapOption::Observe, value);
-    }
-
-    #[deprecated(note = "please use `get_observe_value` instead")]
-    pub fn get_observe(&self) -> Option<&Vec<u8>> {
-        self.get_option(CoapOption::Observe)
-            .and_then(|options| options.front())
-    }
-
     /// Sets the value of the observe option.
     pub fn set_observe_value(&mut self, value: u32) {
         self.clear_option(CoapOption::Observe);

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -283,9 +283,6 @@ impl Packet {
         &self,
         tp: CoapOption,
     ) -> Option<Result<T, IncompatibleOptionValueFormat>> {
-        // TODO: We only need a clone() of the value for string and opaque
-        // types but it's not clear to me how to express this in
-        // OptionValueType
         self.get_first_option(tp)
             .map(|value| T::try_from(value.clone()))
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -88,6 +88,7 @@ impl<Endpoint> CoapRequest<Endpoint> {
         }
     }
 
+    /// Returns the flag in the Observe option.
     pub fn get_observe_flag(&self) -> Option<ObserveOption> {
         self.try_get_observe_flag()
             .and_then(|maybe_flag| maybe_flag.ok())

--- a/src/request.rs
+++ b/src/request.rs
@@ -88,15 +88,9 @@ impl<Endpoint> CoapRequest<Endpoint> {
         }
     }
 
-    /// Returns the flag in the Observe option.
-    pub fn get_observe_flag(&self) -> Option<ObserveOption> {
-        self.try_get_observe_flag()
-            .and_then(|maybe_flag| maybe_flag.ok())
-    }
-
     /// Returns the flag in the Observe option or InvalidObserve if the flag
     /// was provided but not understood.
-    pub fn try_get_observe_flag(
+    pub fn get_observe_flag(
         &self,
     ) -> Option<Result<ObserveOption, InvalidObserve>> {
         self.message.get_observe_value().map(|observe| {
@@ -244,7 +238,7 @@ mod test {
 
         request.message.set_observe_value(32);
         let expected = Some(Err(InvalidObserve));
-        let actual = request.try_get_observe_flag();
+        let actual = request.get_observe_flag();
         assert_eq!(actual, expected);
     }
 
@@ -256,7 +250,7 @@ mod test {
             .message
             .add_option(CoapOption::Observe, b"bunch of nonsense".to_vec());
         let expected = Some(Err(InvalidObserve));
-        let actual = request.try_get_observe_flag();
+        let actual = request.get_observe_flag();
         assert_eq!(actual, expected);
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -94,8 +94,8 @@ impl<Endpoint> CoapRequest<Endpoint> {
             .and_then(|maybe_flag| maybe_flag.ok())
     }
 
-    /// Returns the flag in the Observe option or InvalidObserve if the flag was provided
-    /// but not understood.
+    /// Returns the flag in the Observe option or InvalidObserve if the flag
+    /// was provided but not understood.
     pub fn try_get_observe_flag(
         &self,
     ) -> Option<Result<ObserveOption, InvalidObserve>> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,8 +2,6 @@ use super::{
     header::{MessageClass, MessageType, ResponseType as Status},
     packet::Packet,
 };
-use crate::ObserveOption;
-use core::convert::TryFrom;
 
 /// The CoAP response.
 #[derive(Clone, Debug)]
@@ -87,14 +85,6 @@ impl CoapResponse {
             }
             _ => &Status::UnKnown,
         }
-    }
-
-    #[deprecated(
-        note = "responses must not have observe flag set, use `Packet::set_observe_value` instead"
-    )]
-    pub fn set_observe_flag(&mut self, value: ObserveOption) {
-        let value = u32::try_from(usize::from(value)).unwrap();
-        self.message.set_observe_value(value);
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,8 @@
+use core::convert::TryFrom;
+use crate::ObserveOption;
 use super::{
     header::{MessageClass, MessageType, ResponseType as Status},
-    packet::{ObserveOption, Packet},
+    packet::Packet,
 };
 
 /// The CoAP response.
@@ -87,13 +89,10 @@ impl CoapResponse {
         }
     }
 
-    // Sets the Observe flag.
+    #[deprecated(note = "responses must not have observe flag set, use `Packet::set_observe_value` instead")]
     pub fn set_observe_flag(&mut self, value: ObserveOption) {
-        let value = match value {
-            ObserveOption::Register => alloc::vec![], // Value is not present if Register
-            ObserveOption::Deregister => alloc::vec![value as u8],
-        };
-        self.message.set_observe(value);
+        let value = u32::try_from(usize::from(value)).unwrap();
+        self.message.set_observe_value(value);
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,9 +1,9 @@
-use core::convert::TryFrom;
-use crate::ObserveOption;
 use super::{
     header::{MessageClass, MessageType, ResponseType as Status},
     packet::Packet,
 };
+use crate::ObserveOption;
+use core::convert::TryFrom;
 
 /// The CoAP response.
 #[derive(Clone, Debug)]
@@ -89,7 +89,9 @@ impl CoapResponse {
         }
     }
 
-    #[deprecated(note = "responses must not have observe flag set, use `Packet::set_observe_value` instead")]
+    #[deprecated(
+        note = "responses must not have observe flag set, use `Packet::set_observe_value` instead"
+    )]
     pub fn set_observe_flag(&mut self, value: ObserveOption) {
         let value = u32::try_from(usize::from(value)).unwrap();
         self.message.set_observe_value(value);


### PR DESCRIPTION
Cleans up both option value type handling generally by adding
OptionValueType trait and related getters/setters, but also
specifically for set/get_content_format and set/get_observe.

Also slipped in some cleanup of set/get_observe_flag which was
improper across request/response types and made it difficult
to actually conveniently use my new methods.