### PR TITLE
Expose IncompatibleOptionValueFormat as public

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -69,7 +69,7 @@ impl error::Error for InvalidObserve {}
 /// The error that can occur when parsing an option value.
 #[derive(Debug, PartialEq)]
 pub struct IncompatibleOptionValueFormat {
-    pub(crate) message: String,
+    pub message: String,
 }
 
 impl fmt::Display for IncompatibleOptionValueFormat {


### PR DESCRIPTION
This is actually pretty useful to implement the OptionValueType trait
outside the library and use it for custom options.  But to do this
properly we need the error type to be publicly constructable.