### PR TITLE
Expose reserved message codes in MessageClass.

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -120,6 +120,7 @@ impl From<u8> for MessageClass {
             0xA4 => MessageClass::Response(ResponseType::GatewayTimeout),
             0xA5 => MessageClass::Response(ResponseType::ProxyingNotSupported),
             0xA8 => MessageClass::Response(ResponseType::HopLimitReached),
+
             n => MessageClass::Reserved(n),
         }
     }

--- a/src/header.rs
+++ b/src/header.rs
@@ -137,6 +137,7 @@ impl From<MessageClass> for u8 {
             MessageClass::Request(RequestType::Fetch) => 0x05,
             MessageClass::Request(RequestType::Patch) => 0x06,
             MessageClass::Request(RequestType::IPatch) => 0x07,
+            MessageClass::Request(RequestType::UnKnown) => 0xFF,
 
             MessageClass::Response(ResponseType::Created) => 0x41,
             MessageClass::Response(ResponseType::Deleted) => 0x42,
@@ -173,9 +174,8 @@ impl From<MessageClass> for u8 {
             MessageClass::Response(ResponseType::GatewayTimeout) => 0xA4,
             MessageClass::Response(ResponseType::ProxyingNotSupported) => 0xA5,
             MessageClass::Response(ResponseType::HopLimitReached) => 0xA8,
-
-            MessageClass::Request(RequestType::UnKnown) => 0xFF,
             MessageClass::Response(ResponseType::UnKnown) => 0xFF,
+
             MessageClass::Reserved(c) => c,
         }
     }

--- a/src/header.rs
+++ b/src/header.rs
@@ -69,7 +69,7 @@ pub enum MessageClass {
     Empty,
     Request(RequestType),
     Response(ResponseType),
-    Reserved,
+    Reserved(u8),
 }
 
 impl From<u8> for MessageClass {
@@ -120,7 +120,7 @@ impl From<u8> for MessageClass {
             0xA4 => MessageClass::Response(ResponseType::GatewayTimeout),
             0xA5 => MessageClass::Response(ResponseType::ProxyingNotSupported),
             0xA8 => MessageClass::Response(ResponseType::HopLimitReached),
-            _ => MessageClass::Reserved,
+            n => MessageClass::Reserved(n),
         }
     }
 }
@@ -174,7 +174,9 @@ impl From<MessageClass> for u8 {
             MessageClass::Response(ResponseType::ProxyingNotSupported) => 0xA5,
             MessageClass::Response(ResponseType::HopLimitReached) => 0xA8,
 
-            _ => 0xFF,
+            MessageClass::Request(RequestType::UnKnown) => 0xFF,
+            MessageClass::Response(ResponseType::UnKnown) => 0xFF,
+            MessageClass::Reserved(c) => c,
         }
     }
 }
@@ -376,7 +378,7 @@ mod test {
 
             // Reserved class could technically be many codes, so only check
             // valid items
-            if class != MessageClass::Reserved {
+            if !matches!(class, MessageClass::Reserved(_)) {
                 assert_eq!(u8::from(class), code);
                 assert_eq!(class, header.code);
                 assert_eq!(code_str, header.get_code());


### PR DESCRIPTION
The current API gobbles up the message code when it's not a standard one. I am writing an integration for Shelly IoT sensors that use a non-standard CoAP implementation (such as https://shelly-api-docs.shelly.cloud/gen1/docs/coiot/v1/CoIoT%20for%20Shelly%20devices%20(rev%201.0)%20.pdf).

They'll periodically multicast status messages with the code `30`. This ends up as `MessageClass::Reserved` so I can't verify that it's actually a status message (since there could in theory be any other reserved message). I'd like to expose the underlying message code such that this edge case can be handled by the client.