### PR TITLE
Add UDP feature to tune the max packet size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ default = ["std"]
 std = []
 with-coap-message = ["coap-message"]
 
+# UDP feature enables additional optimizations for CoAP over UDP.
+udp = []
+
 example-server_coaphandler = ["with-coap-message", "coap-handler"]
 
 [badges]

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -361,14 +361,14 @@ pub type Options<'a> =
     alloc::collections::btree_map::Iter<'a, u16, LinkedList<Vec<u8>>>;
 
 impl Packet {
-    /// Max size of payload that CoAP will accept. By default limited to 1280
-    /// so that CoAP packets can be sent over TCP or UDP.
+    /// Maximum allowed packet size. By default limited to 1280 so that CoAP
+    /// packets can be sent over TCP or UDP.
     #[cfg(not(feature = "udp"))]
-    pub const COAP_PAYLOAD_MAX_SIZE: usize = 1280;
+    pub const MAX_SIZE: usize = 1280;
 
-    /// Max size of payload that CoAP will accept.
+    /// Maximum allowed packet size.
     #[cfg(feature = "udp")]
-    pub const COAP_PAYLOAD_MAX_SIZE: usize = 64_000;
+    pub const MAX_SIZE: usize = 64_000;
 
     /// Creates a new packet.
     pub fn new() -> Packet {
@@ -700,7 +700,7 @@ impl Packet {
         }
         buf_length += options_bytes.len();
 
-        if buf_length > Self::COAP_PAYLOAD_MAX_SIZE {
+        if buf_length > Self::MAX_SIZE {
             return Err(MessageError::InvalidPacketLength);
         }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -21,6 +21,14 @@ macro_rules! u8_to_unsigned_be {
     })
 }
 
+/// Max size of Payload that CoAP will accept.
+/// By default limited to 1280 so that CoAP packets can be sent over TCP or UDP.
+#[cfg(not(feature = "udp"))]
+pub const COAP_PAYLOAD_MAX_SIZE: usize = 1280;
+
+#[cfg(feature = "udp")]
+pub const COAP_PAYLOAD_MAX_SIZE: usize = 64_000;
+
 /// The CoAP options.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CoapOption {
@@ -691,7 +699,7 @@ impl Packet {
         }
         buf_length += options_bytes.len();
 
-        if buf_length > 1280 {
+        if buf_length > COAP_PAYLOAD_MAX_SIZE {
             return Err(MessageError::InvalidPacketLength);
         }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -21,14 +21,6 @@ macro_rules! u8_to_unsigned_be {
     })
 }
 
-/// Max size of Payload that CoAP will accept.
-/// By default limited to 1280 so that CoAP packets can be sent over TCP or UDP.
-#[cfg(not(feature = "udp"))]
-pub const COAP_PAYLOAD_MAX_SIZE: usize = 1280;
-
-#[cfg(feature = "udp")]
-pub const COAP_PAYLOAD_MAX_SIZE: usize = 64_000;
-
 /// The CoAP options.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CoapOption {
@@ -369,6 +361,15 @@ pub type Options<'a> =
     alloc::collections::btree_map::Iter<'a, u16, LinkedList<Vec<u8>>>;
 
 impl Packet {
+    /// Max size of payload that CoAP will accept. By default limited to 1280
+    /// so that CoAP packets can be sent over TCP or UDP.
+    #[cfg(not(feature = "udp"))]
+    pub const COAP_PAYLOAD_MAX_SIZE: usize = 1280;
+
+    /// Max size of payload that CoAP will accept.
+    #[cfg(feature = "udp")]
+    pub const COAP_PAYLOAD_MAX_SIZE: usize = 64_000;
+
     /// Creates a new packet.
     pub fn new() -> Packet {
         Default::default()
@@ -699,7 +700,7 @@ impl Packet {
         }
         buf_length += options_bytes.len();
 
-        if buf_length > COAP_PAYLOAD_MAX_SIZE {
+        if buf_length > Self::COAP_PAYLOAD_MAX_SIZE {
             return Err(MessageError::InvalidPacketLength);
         }
 


### PR DESCRIPTION
Problem:
There is a hardcoded limit for the coap payload size.
Which is currently limitted to 1280 bytes.
However, UDP supports payload up to 64KB so this limitation is not
allowing to use all the benefits of UDP protocol.

Solution:
Adding an optional feature `udp` which if enabled will set the max payload size to
64000B, otherwise the default value that is currently set at 1280 will be used

https://github.com/martindisch/coap-lite/issues/25