### PR TITLE
Enable coap-message trait implementations unconditionally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,26 +16,28 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-coap-message = { version = "0.2.3", optional = true }
+coap-message = "0.2.3"
 log = { version = "0.4.19", default-features = false, optional = true }
 lru_time_cache = { version = "0.11.11", optional = true }
 
-# actually they are dev-dependencies, but those can't be optional
-coap-handler = { version = "0.1.5", optional = true }
+[dev-dependencies]
+coap-handler = "0.1.5"
 
 [features]
 default = ["std"]
 std = ["lru_time_cache"]
-with-coap-message = ["coap-message"]
+
+# The dependencies behind these features hasve become non-optional when they
+# became buildable on stable Rust. The features are deprecated to use, and can
+# be removed in a breaking release.
+with-coap-message = []
+example-server_coaphandler = []
 
 # UDP feature enables additional optimizations for CoAP over UDP.
 udp = []
-
-example-server_coaphandler = ["with-coap-message", "coap-handler"]
 
 [badges]
 maintenance = { status = "passively-maintained" }
 
 [[example]]
 name = "server_coaphandler"
-required-features = ["example-server_coaphandler"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,6 @@
 //! [rust-async-coap]: https://github.com/google/rust-async-coap
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "with-coap-message", feature(generic_associated_types))]
 #![allow(clippy::needless_doctest_main)]
 
 #[macro_use]
@@ -143,7 +142,6 @@ mod packet;
 mod request;
 mod response;
 
-#[cfg(feature = "with-coap-message")]
 mod impl_coap_message;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This simplifies Cargo.toml (by placing the coap-handlers dependency correctly as dev-dependency), and avoids code rot that might otherwise be introduced by not regularly testing the implementations' buildability.

---

Until 1.65 is released, this should not be merged, as it'd limit this crate to beta-only. Tests can already be done with the 1.65 beta.

The dependencies' versions were increased not because of changes to the actual code, but because these versions do not have any `#![feature(…)]` set any more, and are thus buildable on stable-to-be.

Note that if this project has an MSRV policy I didn't find, this PR might need to wait until MSRV can be increased to 1.65.