### PR TITLE
Restore #![no_std] support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ doctest = false
 [dependencies]
 coap-message = { version = "^0.2.0-alpha.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
-lru_time_cache = "0.11.11"
+lru_time_cache = { version = "0.11.11", optional = true }
 
 # actually they are dev-dependencies, but those can't be optional
 coap-handler = { version = "^0.1.0-alpha.0", optional = true }
 
 [features]
 default = ["std"]
-std = []
+std = ["lru_time_cache"]
 with-coap-message = ["coap-message"]
 
 # UDP feature enables additional optimizations for CoAP over UDP.

--- a/LICENSE-3RD-PARTY
+++ b/LICENSE-3RD-PARTY
@@ -4,6 +4,7 @@ The MIT License
 applies to:
 - coap, Copyright (c) 2014-2016 Yang Zhang
 - log, Copyright (c) 2014 The Rust Project Developers
+- lru_time_cache, Copyright 2018 MaidSafe.net limited.
 -------------------------------------------------------------------------------
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -232,3 +233,34 @@ applies to:
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+-------------------------------------------------------------------------------
+The BSD 3-Clause "New" or "Revised" License
+
+applies to:
+- lru_time_cache, Copyright 2018 MaidSafe.net limited.
+-------------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ extern crate alloc;
 #[cfg_attr(tarpaulin, skip)]
 pub mod error;
 
+#[cfg(feature = "std")]
 pub mod block_handler;
 mod header;
 pub mod link_format;
@@ -145,6 +146,7 @@ mod response;
 #[cfg(feature = "with-coap-message")]
 mod impl_coap_message;
 
+#[cfg(feature = "std")]
 pub use block_handler::{BlockHandler, BlockHandlerConfig};
 pub use header::{
     Header, HeaderRaw, MessageClass, MessageType, RequestType, ResponseType,


### PR DESCRIPTION
The block handler feature depends on `lru_time_cache`, which requires `std`. This disables the feature and its dependency for `#![no_std]` environments.