### PR TITLE
fix block-wise response token

### DIFF
--- a/src/block_handler/mod.rs
+++ b/src/block_handler/mod.rs
@@ -280,7 +280,6 @@ impl<Endpoint: Ord + Clone> BlockHandler<Endpoint> {
         dst.header.set_version(src.header.get_version());
         dst.header.set_type(src.header.get_type());
         dst.header.code = src.header.code;
-        dst.set_token(src.get_token().to_vec());
         for (&option, value) in src.options() {
             dst.set_option(CoapOption::from(option), value.clone());
         }


### PR DESCRIPTION
Do not reuse token from the original request, always use the token from the current request.

The CoAP specs for block-wise transfer don't specify anything regarding the use of the token. Reusing the token from the original request is non-standard and can break clients.

See [RFC 7959](https://datatracker.ietf.org/doc/html/rfc7959) page 27:
> As a general comment on tokens, there is no other  mention of tokens in this document, as block-wise transfers handle tokens like any other CoAP exchange. As usual, the client is free to choose tokens for each exchange as it likes.