### PR TITLE
Support coap-message 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,26 +16,28 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-coap-message = { version = "0.2.3", optional = true }
+coap-message = "0.2.3"
 log = { version = "0.4.19", default-features = false, optional = true }
 lru_time_cache = { version = "0.11.11", optional = true }
 
-# actually they are dev-dependencies, but those can't be optional
-coap-handler = { version = "0.1.5", optional = true }
+[dev-dependencies]
+coap-handler = "0.1.5"
 
 [features]
 default = ["std"]
 std = ["lru_time_cache"]
-with-coap-message = ["coap-message"]
+
+# The dependencies behind these features hasve become non-optional when they
+# became buildable on stable Rust. The features are deprecated to use, and can
+# be removed in a breaking release.
+with-coap-message = []
+example-server_coaphandler = []
 
 # UDP feature enables additional optimizations for CoAP over UDP.
 udp = []
-
-example-server_coaphandler = ["with-coap-message", "coap-handler"]
 
 [badges]
 maintenance = { status = "passively-maintained" }
 
 [[example]]
 name = "server_coaphandler"
-required-features = ["example-server_coaphandler"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [dependencies]
 coap-message = "0.2.3"
+coap-message-0-3 = { package = "coap-message", version = "0.3" }
 log = { version = "0.4.19", default-features = false, optional = true }
 lru_time_cache = { version = "0.11.11", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ log = { version = "0.4.19", default-features = false, optional = true }
 lru_time_cache = { version = "0.11.11", optional = true }
 
 [dev-dependencies]
-coap-handler = "0.1.5"
+coap-handler = "0.2.0"
+coap-handler-implementations = "0.5.0"
 
 [features]
 default = ["std"]

--- a/src/impl_coap_message.rs
+++ b/src/impl_coap_message.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use coap_message::{
     Code, MinimalWritableMessage, MutableWritableMessage, OptionNumber,
     ReadableMessage, SeekWritableMessage, WithSortedOptions,

--- a/src/impl_coap_message_0_3.rs
+++ b/src/impl_coap_message_0_3.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use coap_message_0_3 as coap_message;
 
 use coap_message_0_3::{

--- a/src/impl_coap_message_0_3.rs
+++ b/src/impl_coap_message_0_3.rs
@@ -1,0 +1,143 @@
+use coap_message_0_3 as coap_message;
+
+use coap_message_0_3::{
+    Code, MinimalWritableMessage, MutableWritableMessage, OptionNumber,
+    ReadableMessage, SeekWritableMessage, WithSortedOptions,
+};
+
+use crate::{CoapOption, MessageClass, Packet};
+
+impl Code for MessageClass {
+    type Error = core::convert::Infallible;
+
+    fn new(code: u8) -> Result<Self, core::convert::Infallible> {
+        Ok(code.into())
+    }
+}
+
+// pub only in name: We don't expose this whole module, so all users will know
+// is that this is a suitable iterator.
+pub struct MessageOptionAdapter<'a> {
+    head: Option<(u16, alloc::collections::linked_list::Iter<'a, Vec<u8>>)>,
+    // right from Packet::options -- fortunately that doesn't say that it
+    // returns an impl Iterator
+    raw_iter: alloc::collections::btree_map::Iter<
+        'a,
+        u16,
+        alloc::collections::linked_list::LinkedList<Vec<u8>>,
+    >,
+}
+
+// pub only in name: We don't expose this whole module, so all users will know
+// is that this implements coap_message::MessageOption
+pub struct MessageOption<'a> {
+    number: u16,
+    value: &'a [u8],
+}
+
+impl<'a> Iterator for MessageOptionAdapter<'a> {
+    type Item = MessageOption<'a>;
+
+    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
+        loop {
+            if let Some((number, values)) = self.head.as_mut() {
+                if let Some(value) = values.next() {
+                    return Some(MessageOption {
+                        number: *number,
+                        value,
+                    });
+                }
+            }
+            let (number, values) = self.raw_iter.next()?;
+            self.head = Some((*number, values.iter()));
+        }
+    }
+}
+
+impl<'a> coap_message::MessageOption for MessageOption<'a> {
+    fn number(&self) -> u16 {
+        self.number.into()
+    }
+    fn value(&self) -> &[u8] {
+        self.value
+    }
+}
+
+impl ReadableMessage for Packet {
+    type Code = MessageClass;
+
+    type MessageOption<'a> = MessageOption<'a>;
+    type OptionsIter<'a> = MessageOptionAdapter<'a>;
+
+    fn code(&self) -> Self::Code {
+        self.header.code
+    }
+    fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+    fn options<'a>(&'a self) -> Self::OptionsIter<'a> {
+        MessageOptionAdapter {
+            raw_iter: (&self.options).iter(),
+            head: None,
+        }
+    }
+}
+
+impl<'a> WithSortedOptions for Packet {}
+
+impl OptionNumber for CoapOption {
+    type Error = core::convert::Infallible;
+
+    fn new(option: u16) -> Result<Self, core::convert::Infallible> {
+        Ok(option.into())
+    }
+}
+
+impl MinimalWritableMessage for Packet {
+    type Code = MessageClass;
+    type OptionNumber = CoapOption;
+
+    type AddOptionError = core::convert::Infallible;
+    type SetPayloadError = core::convert::Infallible;
+    type UnionError = core::convert::Infallible;
+
+    fn set_code(&mut self, code: Self::Code) {
+        self.header.code = code;
+    }
+
+    fn add_option(&mut self, option: Self::OptionNumber, data: &[u8]) -> Result<(), Self::AddOptionError> {
+        self.add_option(option, data.into());
+        Ok(())
+    }
+
+    fn set_payload(&mut self, payload: &[u8]) -> Result<(), Self::SetPayloadError> {
+        self.payload = payload.into();
+        Ok(())
+    }
+}
+
+impl MutableWritableMessage for Packet {
+    fn available_space(&self) -> usize {
+        usize::MAX
+    }
+    fn payload_mut_with_len(&mut self, len: usize) -> Result<&mut [u8], Self::SetPayloadError> {
+        self.payload.resize(len, 0);
+        Ok(&mut self.payload)
+    }
+    fn truncate(&mut self, length: usize) -> Result<(), Self::SetPayloadError> {
+        self.payload.truncate(length);
+        Ok(())
+    }
+    fn mutate_options<F>(&mut self, mut callback: F)
+    where
+        F: FnMut(Self::OptionNumber, &mut [u8]),
+    {
+        for (&number, ref mut values) in self.options.iter_mut() {
+            for v in values.iter_mut() {
+                callback(number.into(), v);
+            }
+        }
+    }
+}
+
+impl SeekWritableMessage for Packet {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,6 @@
 //! [rust-async-coap]: https://github.com/google/rust-async-coap
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "with-coap-message", feature(generic_associated_types))]
 #![allow(clippy::needless_doctest_main)]
 
 #[macro_use]
@@ -143,7 +142,6 @@ mod packet;
 mod request;
 mod response;
 
-#[cfg(feature = "with-coap-message")]
 mod impl_coap_message;
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ mod request;
 mod response;
 
 mod impl_coap_message;
+mod impl_coap_message_0_3;
 
 #[cfg(feature = "std")]
 pub use block_handler::{BlockHandler, BlockHandlerConfig};

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -472,6 +472,11 @@ impl Packet {
         }
     }
 
+    /// Removes all options.
+    pub fn clear_all_options(&mut self) {
+        self.options.clear()
+    }
+
     /// Sets the content-format.
     pub fn set_content_format(&mut self, cf: ContentFormat) {
         let content_format: u16 = u16::try_from(usize::from(cf)).unwrap();


### PR DESCRIPTION
This adds support for coap-message 0.3 in parallel to the existing 0.2 support, in a semver compatible manner.

While it'd be possible to "just update" the code, having both (at least for the duration of the 0.11 series, but I'd hope that those traits have been low-maintenance for you since their introduction in 0.4) gives users a smoother upgrade path.

There is one addition outside of the traits that is necessary to implement use the new coap-message version, as illustrated in the updated example: A clear_all_options option is introduced. This generally allows server applications to roll back out of a situation when a delegated handler was allowed to populate a message and failed somewhere deep in there -- a style of error recovery embraced in the crates around coap-message (in particular, coap-handler).