### PR TITLE
fix: Handle integer overflow in option delta and length

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -562,7 +562,9 @@ impl Packet {
                                 idx,
                                 idx + 1,
                                 u16
-                            )).checked_add(269).ok_or(MessageError::InvalidOptionDelta)?;
+                            ))
+                            .checked_add(269)
+                            .ok_or(MessageError::InvalidOptionDelta)?;
                             idx += 2;
                         }
                         15 => {
@@ -591,7 +593,10 @@ impl Packet {
                                 idx,
                                 idx + 1,
                                 u16
-                            )).checked_add(269).ok_or(MessageError::InvalidOptionLength)?).into();
+                            ))
+                            .checked_add(269)
+                            .ok_or(MessageError::InvalidOptionLength)?)
+                            .into();
                             idx += 2;
                         }
                         15 => {
@@ -1035,7 +1040,10 @@ mod test {
         let output = Packet::from_bytes(&bytes).unwrap();
         assert_eq!(output.options().len(), 2);
         assert_eq!(output.get_first_option(option_1), Some(vec![0]).as_ref());
-        assert_eq!(output.get_first_option(option_258), Some(vec![1]).as_ref());
+        assert_eq!(
+            output.get_first_option(option_258),
+            Some(vec![1]).as_ref()
+        );
     }
 
     #[test]


### PR DESCRIPTION
There are a few integer overflows when decoding an option's delta and length fields. These overflows lead to `Packet::from_bytes` incorrectly decoding some valid packets, and incorrectly returning garbage data for some invalid packets.

This fix checks all arithmetic, and adds unit tests to verify the new behavior is correct.