### PR TITLE
change get_status to use the `ref` keyword and always return a code if a response is available

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -36,51 +36,7 @@ impl CoapResponse {
     /// Returns the status.
     pub fn get_status(&self) -> &Status {
         match self.message.header.code {
-            MessageClass::Response(Status::Created) => &Status::Created,
-            MessageClass::Response(Status::Deleted) => &Status::Deleted,
-            MessageClass::Response(Status::Valid) => &Status::Valid,
-            MessageClass::Response(Status::Changed) => &Status::Changed,
-            MessageClass::Response(Status::Content) => &Status::Content,
-
-            MessageClass::Response(Status::BadRequest) => &Status::BadRequest,
-            MessageClass::Response(Status::Unauthorized) => {
-                &Status::Unauthorized
-            }
-            MessageClass::Response(Status::BadOption) => &Status::BadOption,
-            MessageClass::Response(Status::Forbidden) => &Status::Forbidden,
-            MessageClass::Response(Status::NotFound) => &Status::NotFound,
-            MessageClass::Response(Status::MethodNotAllowed) => {
-                &Status::MethodNotAllowed
-            }
-            MessageClass::Response(Status::NotAcceptable) => {
-                &Status::NotAcceptable
-            }
-            MessageClass::Response(Status::PreconditionFailed) => {
-                &Status::PreconditionFailed
-            }
-            MessageClass::Response(Status::RequestEntityTooLarge) => {
-                &Status::RequestEntityTooLarge
-            }
-            MessageClass::Response(Status::UnsupportedContentFormat) => {
-                &Status::UnsupportedContentFormat
-            }
-
-            MessageClass::Response(Status::InternalServerError) => {
-                &Status::InternalServerError
-            }
-            MessageClass::Response(Status::NotImplemented) => {
-                &Status::NotImplemented
-            }
-            MessageClass::Response(Status::BadGateway) => &Status::BadGateway,
-            MessageClass::Response(Status::ServiceUnavailable) => {
-                &Status::ServiceUnavailable
-            }
-            MessageClass::Response(Status::GatewayTimeout) => {
-                &Status::GatewayTimeout
-            }
-            MessageClass::Response(Status::ProxyingNotSupported) => {
-                &Status::ProxyingNotSupported
-            }
+            MessageClass::Response(ref code) => code,
             _ => &Status::UnKnown,
         }
     }


### PR DESCRIPTION
using `ref` simplifies most of the manual typing used here

-- reason I am making the PR is that I had a response code that was not in the match statement